### PR TITLE
Phase 5: scale coordination and lean project knowledge

### DIFF
--- a/skill/references/continuity.md
+++ b/skill/references/continuity.md
@@ -37,7 +37,7 @@ Keep cold recovery progressive and bounded:
 - **Active-path context:** enter only the repository/workstream sources needed for the next decision: current Issue/contract, PR/branch/CI, direct dependencies/interfaces, blockers/risks, and integration/delivery state.
 - **Triggered depth:** load broader architecture, other workstreams, root specification, historical decisions, or release history only when a contradiction, dependency, interface, risk, or project-level decision makes that context materially relevant.
 
-Stop recovery reading once repository/target identity, active outcome, controlling dependencies/blockers, required authority/profile, current candidate/review/delivery state, and the next executable action are decision-valid. A large repository or long-lived project is a reason to narrow recovery by workstream, not to read more by default.
+Stop recovery reading once repository/target identity, active outcome, controlling dependencies/blockers, current `ProjectAuthority`/`CoordinationBaseline`/affected `AssuranceLevel`, current candidate/review/delivery state, and the next executable action are decision-valid. A large repository or long-lived project is a reason to narrow recovery by workstream, not to read more by default.
 
 For multi-repository outcomes, recover the small global coordination spine first: outcome/completion, repository/workstream ownership, cross-repository dependencies/interfaces, integration/release order, and delivery target. Then enter only the local repository contexts on the active critical path. Local Issues/PRs/CI/repository rules remain authoritative; do not reconstruct them in a central recovery snapshot.
 

--- a/skill/references/continuity.md
+++ b/skill/references/continuity.md
@@ -33,7 +33,7 @@ A new/replacement Master enters `RECOVER` before consequential project mutation:
 
 Keep cold recovery progressive and bounded:
 
-- **Orientation spine:** establish repository/repositories, current project outcome/completion, Project Map or equivalent truth-location index, current authority/profile, and the active critical path/workstream.
+- **Orientation spine:** establish repository/repositories, current project outcome/completion, Project Map or equivalent truth-location index, `ProjectAuthority`, `CoordinationBaseline`, any currently affected `AssuranceLevel`, and the active critical path/workstream.
 - **Active-path context:** enter only the repository/workstream sources needed for the next decision: current Issue/contract, PR/branch/CI, direct dependencies/interfaces, blockers/risks, and integration/delivery state.
 - **Triggered depth:** load broader architecture, other workstreams, root specification, historical decisions, or release history only when a contradiction, dependency, interface, risk, or project-level decision makes that context materially relevant.
 

--- a/skill/references/continuity.md
+++ b/skill/references/continuity.md
@@ -31,9 +31,19 @@ A new/replacement Master enters `RECOVER` before consequential project mutation:
 7. determine active outcome/completion condition, review queue, blockers, `DeliveryRequirement`/`DeliveryTarget`/`DeliveryState`, and next executable action; recover `ProjectAuthority` and `CoordinationBaseline` independently, plus any affected-chain `AssuranceLevel` and exact current `ScopedAuthorization`;
 8. continue the valid plan instead of rebuilding it because chat history is absent.
 
+Keep cold recovery progressive and bounded:
+
+- **Orientation spine:** establish repository/repositories, current project outcome/completion, Project Map or equivalent truth-location index, current authority/profile, and the active critical path/workstream.
+- **Active-path context:** enter only the repository/workstream sources needed for the next decision: current Issue/contract, PR/branch/CI, direct dependencies/interfaces, blockers/risks, and integration/delivery state.
+- **Triggered depth:** load broader architecture, other workstreams, root specification, historical decisions, or release history only when a contradiction, dependency, interface, risk, or project-level decision makes that context materially relevant.
+
+Stop recovery reading once repository/target identity, active outcome, controlling dependencies/blockers, required authority/profile, current candidate/review/delivery state, and the next executable action are decision-valid. A large repository or long-lived project is a reason to narrow recovery by workstream, not to read more by default.
+
+For multi-repository outcomes, recover the small global coordination spine first: outcome/completion, repository/workstream ownership, cross-repository dependencies/interfaces, integration/release order, and delivery target. Then enter only the local repository contexts on the active critical path. Local Issues/PRs/CI/repository rules remain authoritative; do not reconstruct them in a central recovery snapshot.
+
 Never reconstruct `CoordinationBaseline` from `AssuranceLevel`, risk, project size, or technical access. Legacy `Operating Profile: LIGHTWEIGHT|STANDARD` can be interpreted losslessly as the same CoordinationBaseline with `AssuranceLevel=NORMAL`. Legacy `Operating Profile: HIGH_ASSURANCE` is not enough to identify its missing coordination baseline: recover that baseline from authoritative persisted project/assignment state or preserve the ambiguity until it is resolved; do not guess.
 
-After this baseline is established, do not re-enter the full recovery sequence for ordinary progress. A planned branch/worktree create/switch should verify the intended branch, base/HEAD, target relationship, and dirty-state ownership as needed, then resume execution. A failed GitHub/tool route should update transient capability knowledge and trigger an equivalent authoritative route when available; it should not by itself restart repository-wide recovery. Re-enter broader recovery only when concrete evidence materially invalidates the established baseline.
+After this baseline is established, do not re-enter the full recovery sequence for ordinary progress. A planned branch/worktree create/switch should verify the intended branch, base/HEAD, target relationship, and dirty-state ownership as needed, then resume execution. A failed GitHub/tool route should update transient capability knowledge and trigger an equivalent authoritative route when available; it should not by itself restart repository-wide recovery. Re-enter broader recovery only when concrete evidence materially invalidates the established baseline. When a material dependency, architecture/interface assumption, ownership boundary, risk, or release constraint changes, reconcile the affected workstream/critical-path slice first and widen recovery only when the impact actually crosses that boundary.
 
 Old handoff hints are accelerators only. `scripts/repo_preflight.py --recovery` may accelerate local Git inspection but is transient and incomplete. Treat any explicit completeness flag as authoritative for the helper output: when `status_complete`/`dirty_complete` is false, `dirty: false` means no dirty state was safely observed, not proof that the worktree is clean; when history/tag completeness is false, do not infer absence from the missing local evidence. Its high-cardinality status/branch lists are intentionally bounded; when `*_truncated` is true, use the reported totals plus targeted Git inspection for the paths/refs relevant to recovery rather than treating the returned subset as complete. The helper intentionally avoids implicit lazy fetches and reports replacement/graft history semantics; perform explicit authorized fetches or targeted trusted inspection only when the missing evidence can affect the next decision.
 
@@ -43,7 +53,8 @@ When state is stale or contradictory:
 
 - prefer current direct evidence using the source hierarchy in `SKILL.md`;
 - correct the authoritative current source rather than adding a compensating note elsewhere;
-- close/supersede duplicates only after confirming intent/current work;
+- repair/remove stale Project Map or relationship pointers after the authoritative target is reconciled; never preserve a misleading link merely to explain history;
+- close/supersede duplicates only after confirming intent/current work, and keep the surviving authoritative owner rather than creating another summary artifact;
 - preserve concurrent valid work and use optimistic concurrency for overwrite-sensitive updates;
 - do not infer `DeliveryState.DELIVERED` from `TaskState.INTEGRATED`, target/environment naming, or stale status fields;
 - do not infer a `MasterBoundary` from matching `TaskState`/`WorkerStatus`/`WriteState`/`DeliveryState` token text;
@@ -60,6 +71,8 @@ A replacement Master with no chat history should be able to find, when relevant:
 - unresolved lasting decisions;
 - release/deployment state including independent `DeliveryRequirement`, `DeliveryTarget`, and `DeliveryState`, plus next valid action;
 - authoritative locations and material relationships without chat history.
+
+For large or multi-repository projects, the test is satisfied when the replacement Master can find the global outcome/dependency/release spine and then reach the active local workstream sources progressively; it does **not** require an exhaustive central snapshot of every repository or work item.
 
 If not, persist only the missing future-useful fact in its proper source. Do not duplicate facts already reconstructable from Git/GitHub merely to make recovery faster, and do not promote a transient task to a standalone Issue when an existing PR/commit/work item already makes its intent recoverable.
 

--- a/skill/references/governance.md
+++ b/skill/references/governance.md
@@ -42,7 +42,11 @@ When ordering READY work, consider critical-path impact, blocker unlocks, correc
 
 Milestones should represent coherent outcomes or release boundaries, not arbitrary time buckets unless the team already uses time-boxed planning. Treat a requested date as a constraint, not proof of feasibility: do not invent ETAs. Forecast from current scope, dependencies, risk, and available capacity; when date, scope, and required quality/risk controls conflict, surface the trade-off instead of silently promising all three.
 
-If one outcome spans multiple repositories/services, keep one coherent cross-repository outcome/release view while preserving each repository's own rules, Issues/PRs, CI, and ownership. Make cross-repository dependencies and release order explicit only where coordination requires them; do not create a duplicate central backlog that mirrors every repo.
+If one outcome spans multiple repositories/services, keep one coherent cross-repository outcome/release view while preserving each repository's own rules, Issues/PRs, CI, and ownership. The cross-repository view should contain only the global outcome/completion model, material cross-repository dependencies, release/integration order, and ownership/handoff links needed to coordinate them. Keep implementation status and local backlog in each repository's natural authoritative sources; do not create a duplicate central backlog that mirrors every repo.
+
+Scale coordination by **coordination shape**, not repository size. When a large project has separable components or workstreams, partition execution into bounded workstream contexts instead of loading the full project into every decision. Persist a workstream boundary only when it materially improves coordination or recovery, and keep it minimal: the outcome slice, responsible owner/Worker or component boundary, authoritative local work source, material interfaces/dependencies, and integration/release handoff. Do not mirror local task status into a central workstream document.
+
+Reassess plan validity when a material dependency, risk, architecture/interface assumption, ownership boundary, or release constraint changes. Revalidate only the affected workstream(s), critical-path relationships, and integration/release assumptions first; widen only when the change actually propagates. Do not turn plan-health checking into a recurring audit program.
 
 ## 4. GitHub state model
 
@@ -75,7 +79,7 @@ Update the Project Map only when the information topology changes: an authoritat
 
 Maintain relationship links as work evolves, using native GitHub relationships/closing keywords/URLs where possible: milestone or parent -> Issue, Issue -> dependency/blocker, PR -> Issue/Task Contract, Issue/PR -> lasting ADR when relevant, and release/deployment -> immutable commit/artifact identity. Add only links that improve navigation, dependency reasoning, review, release traceability, or recovery; do not mirror the same state in prose.
 
-A replacement Master should be able to start from the Project Map (when present) and traverse authoritative links to current work without reading historical chat.
+When the Project Map or a relationship is stale or duplicated, repair/remove the pointer and correct the underlying authoritative owner if its state is wrong. Do not add compensating notes, shadow status, or another index to explain stale truth. A replacement Master should be able to start from the Project Map (when present), select the relevant workstream/repository, and traverse authoritative links to current work without reading historical chat or the entire project corpus.
 
 ## 6. Label taxonomy
 
@@ -161,6 +165,16 @@ Use for a bounded outcome with low coordination overhead and no material multi-i
 ### `CoordinationBaseline=STANDARD`
 
 Use when multiple substantive items, dependencies, multiple/overlapping Workers, material delegation coordination, review/release coordination, or broader cross-session project coordination materially benefit from persistent project state. Expect reproducible setup, CI for core checks, PR-based code integration when that is the repository-normal/practical control path, or an established equivalent non-PR path only when it preserves the same review/freshness/audit/gate outcomes; clear persisted contracts where coordination requires them; milestone/release tracking where useful; current engineering/release docs; and explicit active risks/decisions when material. A bounded independent change may still use `ExecutionPath=FAST` when FAST criteria hold.
+
+Select the baseline from actual coordination needs rather than size labels:
+
+| Representative shape | Default behavior |
+|---|---|
+| small/bounded | stay `LIGHTWEIGHT` while one clear path remains independently recoverable and low-coordination |
+| medium/multi-item | use `LIGHTWEIGHT` for genuinely independent bounded work; select `STANDARD` when dependencies, shared ownership, review/release coordination, or cross-session state materially benefit from it |
+| large/multi-repository | normally retain/select `STANDARD` when coordination needs justify it, but partition into bounded component/workstream contexts; do not create a larger profile, global task mirror, or exhaustive context load merely because the system is large |
+
+For `STANDARD` work at scale, persist only coordination edges that change decisions: cross-workstream dependencies, ownership/handoff boundaries, shared interface assumptions, integration order, and release constraints. Local implementation truth remains in each natural repository/Issue/PR/CI source.
 
 ### `AssuranceLevel=HIGH_ASSURANCE`
 


### PR DESCRIPTION
Closes #8 when Phase 5 acceptance is complete.

## Goal
Strengthen large-project coordination and zero-chat recovery without creating a central information bottleneck or making small projects inherit large-project ceremony.

## Changes
- Select coordination by coordination shape, not repository size; add explicit small/medium/large representative behavior.
- Partition large projects into bounded workstream contexts with minimal ownership/dependency/integration boundaries instead of central status mirrors.
- Keep multi-repository coordination to a small global outcome/dependency/release spine while local Issues/PRs/CI remain authoritative.
- Revalidate only affected workstreams when dependency/risk/architecture/ownership/release assumptions materially change.
- Make cold recovery progressive: orientation spine -> active-path context -> triggered depth, with an explicit stop-reading condition once the next action is decision-valid.
- Repair stale Project Map/relationship pointers at their authoritative owners instead of adding compensating documentation.

## Validation plan
- `python3 tools/validate_skill.py skill`
- existing Phase 2 compatibility tests
- immutable `v1.0.0` baseline verification
- regression review against representative LIGHTWEIGHT/STANDARD/large-repo/recovery/improvement scenarios in `eval-scenarios.md`
- effective-diff review against current `main`

## Non-goals
- No duplicate central backlog or manager-memory archive.
- No periodic optimization/audit program.
- No Phase 6 deterministic lint/traceability implementation.

Branch started from `main@7acf72b3506518f8b0e2400806e83a07fe2cc31a`.