### PR TITLE
Phase 6: add deterministic lint and traceability enforcement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Test Phase 2 contract compatibility
         run: python3 tests/test_contract_check_phase2.py
 
+      - name: Test Phase 6 deterministic lint
+        run: python3 tests/test_validate_skill_phase6.py
+
       - name: Verify immutable v1.0.0 baseline
         shell: bash
         run: |

--- a/design/GOAL-MAP.md
+++ b/design/GOAL-MAP.md
@@ -6,26 +6,26 @@ Status: development-only traceability layer. Canonical goal definitions live in 
 
 Use this map to prevent refactors from optimizing local wording while losing project-level intent. Every material runtime change should identify the Goal IDs it advances and the Rule IDs/evaluations it can affect.
 
-Mappings below are representative, not exhaustive. Rule-level completeness remains owned by `RULE-MAP.md` and evaluation completeness by `skill/references/eval-scenarios.md` plus later regression additions.
+Goal rows may emphasize primary families rather than every secondary relationship, but **Rule ID coverage is mechanically exhaustive**: every canonical Rule ID in `RULE-MAP.md` must appear in at least one Goal row below. Every explicit eval anchor in this file and `RULE-MAP.md` must resolve to a real scenario in `skill/references/eval-scenarios.md`.
 
 | Goal | Primary rule families / Rule IDs | Existing evaluation anchors | Additional coverage to add during refactor |
 |---|---|---|---|
-| `G01` Verified End-to-End Delivery | `OUTCOME-STABLE`, `POST-INTEGRATION-RECONCILE`, release/delivery rules | P, AY, CO, CT | end-to-end synthetic project from intake through required delivery |
-| `G02` Outcome & Scope Integrity | `OUTCOME-STABLE`, requirement/root-spec change rules | AY, BA, BZ, CA, CB, CD, CY | cross-workstream requirement change with unaffected work continuing |
-| `G03` Adaptive Planning & Decomposition | `WORK-CLEAR-ENOUGH`, `FAST-FULL-SELECT`, `SYNTHESIZE-WORK`, governance planning hierarchy | K, L, O, AB, AZ | decomposition quality across small/medium/large outcomes |
-| `G04` Dependency, Flow & Project Health Management | `WIP-FLOW`, `SYNTHESIZE-WORK`, `MASTER-STOP-CANONICAL` | J, O, R, AP, CN | explicit plan-validity/critical-path-change and project-health scenarios |
-| `G05` Professional Engineering Execution | self-execution discipline, `PROTECT-UNRELATED`, validation/review rules | X, Y, AC, CL | root-cause vs symptom-patch representative coding benchmark |
+| `G01` Verified End-to-End Delivery | `OUTCOME-STABLE`, `POST-INTEGRATION-RECONCILE`, `INTEGRATED-NOT-DELIVERED`, `POST-RELEASE-EVIDENCE`, `RELEASE-CLOSEOUT` | P, AY, CO, CT | end-to-end synthetic project from intake through required delivery |
+| `G02` Outcome & Scope Integrity | `OUTCOME-STABLE`, `ROOT-SPEC-CANONICAL`, `ROOT-SPEC-OFF-HOT-PATH`, `MATERIAL-DECISION-BOUNDARY` | AY, BA, BZ, CA, CB, CD, CY | cross-workstream requirement change with unaffected work continuing |
+| `G03` Adaptive Planning & Decomposition | `WORK-CLEAR-ENOUGH`, `FAST-FULL-SELECT`, `CONTRACT-PERSISTENCE-INDEPENDENT`, `SYNTHESIZE-WORK` | K, L, O, AB, AZ, CM | decomposition quality across small/medium/large outcomes |
+| `G04` Dependency, Flow & Project Health Management | `WIP-FLOW`, `SYNTHESIZE-WORK`, `MASTER-STOP-CANONICAL`, `DRIFT-RECONCILE`, `CONCURRENCY-OPTIMISTIC` | J, O, R, AP, CN, BH | explicit plan-validity/critical-path-change and project-health scenarios |
+| `G05` Professional Engineering Execution | `PROTECT-UNRELATED`, `SELF-EXECUTION-FALLBACK`, `CI-CLASSIFY`, `CONFLICT-RECONCILE`, `READY-DONE-SEMANTICS` | X, Y, AC, CL, Q, BE | root-cause vs symptom-patch representative coding benchmark |
 | `G06` Architecture & Engineering-System Evolution | `ARTIFACT-FITNESS`, `BOOTSTRAP-PROPORTIONAL`, `LEAN-ORCHESTRATION` | AZ, BS, BT, BU | architecture-drift and developer-feedback-loop improvement scenarios |
-| `G07` Engineering Quality & Evidence | `EVIDENCE-BEATS-NARRATIVE`, `REVIEW-EFFECTIVE-CHANGE`, `REVIEW-IDENTITY-FRESH`, `CI-CLASSIFY` | E, F, M, AC, CL | quality benchmark spanning correctness/security/performance/operations |
-| `G08` Scale-Adaptive Coordination | `COORDINATION-BASELINE`, `DIMENSIONS-ORTHOGONAL`, `DELEGATION-PROPORTIONAL`, `WIP-FLOW` | W, AB, AN, CE, CF | large/multi-repo bounded-context and component/workstream ownership test |
-| `G09` Professional Delegation & Ownership | `WORKER-BOUNDED`, `ASSIGNMENT-IDENTITY`, `STALE-ASSIGNMENT`, `WORKER-STOP-LOCAL`, `WORKER-TARGET-SEPARATION` | D, R, AK, AM, AV, CK, CP, CR | multiple independent Workers with Master replacement mid-flight |
-| `G10` Authority, Risk & Safety Integrity | `AUTHORITY-STABLE`, `AUTHORIZATION-SCOPED`, `CAPABILITY-NOT-AUTHORITY`, `EFFECT-ACTUAL`, `EFFECT-MULTI`, `GATE-UNION` | H, AH, AJ, BP, CG, CH, CU, CV, CX | ontology-normalized multi-effect obligation-union tests |
-| `G11` Verified Review, Integration, Release & Operations | review/integration family, delivery/release rules | E, G, H, CJ, CO, CT | complete release path tied to immutable artifact and delivery evidence |
-| `G12` Zero-Chat Recoverability & Succession | `SUCCESSION-RECOVERABLE`, `RECOVERY-EVENT-DRIVEN`, `RECOVERY-AUTHORITATIVE`, `CHAT-NONAUTHORITATIVE`, `ROTATION-SAFE-BOUNDARY` | I, Z, U, AH, AK, BB, BG, BH | formal cold-recovery benchmark with zero conversation context |
-| `G13` Lean Navigable Project Knowledge | `TRUTH-ONE-OWNER`, `LEAN-ORCHESTRATION`, governance Project Map/link discipline, continuity retention test | A, I, Z, AZ, BT | bounded recovery-cost test; stale/duplicate information entropy test |
-| `G14` Repository Readiness, Hygiene & Self-Repair | `BOOTSTRAP-PROPORTIONAL`, `ARTIFACT-FITNESS`, `MUTATION-IDEMPOTENT` | A, B, AU, AZ, BS, BT, BU | stale project-system cleanup without parallel duplicate mechanisms |
-| `G15` Proactive Improvement Without Scope Creep | `OUTCOME-STABLE`, improvement classifier, `LEAN-ORCHESTRATION` | Y, AX, AY, BA, BT, BU, CB | improvement proposal/execute/ignore classification benchmark |
-| `G16` Persistent Progress Without Friction | `ANTI-SPIN`, `SYNTHESIZE-WORK`, `MASTER-STOP-CANONICAL`, `WORKER-STOP-LOCAL` | O, Q, R, T, AP, AQ, AW, AX, CN, CQ | decision/tool-step benchmark before first useful action and across local blockers |
+| `G07` Engineering Quality & Evidence | `EVIDENCE-BEATS-NARRATIVE`, `NO-FABRICATION`, `REVIEW-EFFECTIVE-CHANGE`, `REVIEW-IDENTITY-FRESH`, `UNTRUSTED-EXECUTION-SURFACE`, `CI-CLASSIFY`, `SELF-AUTHORED-FRESH-REVIEW`, `POST-RELEASE-EVIDENCE` | E, F, M, AC, CL, BC, CO | quality benchmark spanning correctness/security/performance/operations |
+| `G08` Scale-Adaptive Coordination | `COORDINATION-BASELINE`, `DIMENSIONS-ORTHOGONAL`, `DELEGATION-PROPORTIONAL`, `CONTRACT-PERSISTENCE-INDEPENDENT`, `WIP-FLOW` | W, AB, AN, CE, CF, CZ | large/multi-repo bounded-context and component/workstream ownership test |
+| `G09` Professional Delegation & Ownership | `WORKER-BOUNDED`, `ASSIGNMENT-IDENTITY`, `START-HEAD-HISTORICAL`, `CORRECTION-CHECKPOINT`, `STALE-ASSIGNMENT`, `WORKER-STOP-LOCAL`, `WORKER-HANDOFF-PRECEDENCE`, `WORKER-TARGET-SEPARATION`, `DELEGATION-PROPORTIONAL` | D, R, AK, AM, AV, CK, CP, CR | multiple independent Workers with Master replacement mid-flight |
+| `G10` Authority, Risk & Safety Integrity | `AUTHORITY-STABLE`, `AUTHORIZATION-SCOPED`, `CAPABILITY-NOT-AUTHORITY`, `EFFECT-ACTUAL`, `EFFECT-MULTI`, `GATE-NO-INVENTION`, `GATE-UNION`, `WRITE-UNKNOWN-RECONCILE`, `CONCURRENCY-OPTIMISTIC`, `MATERIAL-DECISION-BOUNDARY`, `ASSURANCE-ADDITIVE`, `RISK-SCOPED` | H, AH, AJ, BP, CG, CH, CU, CV, CX, C, CW | ontology-normalized multi-effect obligation-union tests |
+| `G11` Verified Review, Integration, Release & Operations | `REVIEW-EFFECTIVE-CHANGE`, `REVIEW-IDENTITY-FRESH`, `UNTRUSTED-EXECUTION-SURFACE`, `CI-CLASSIFY`, `CONFLICT-RECONCILE`, `INTEGRATION-GATE`, `SELF-AUTHORED-FRESH-REVIEW`, `POST-INTEGRATION-RECONCILE`, `RELEASE-MODEL-DISCOVER`, `INTEGRATED-NOT-DELIVERED`, `PRODUCTION-DETERMINISTIC-EFFECT`, `MIGRATION-ROLLBACK`, `PRODUCTION-GATE`, `POST-RELEASE-EVIDENCE`, `INCIDENT-CONTAINMENT`, `RELEASE-CLOSEOUT` | E, G, H, CJ, CO, CT, CS, BO, CV | complete release path tied to immutable artifact and delivery evidence |
+| `G12` Zero-Chat Recoverability & Succession | `SUCCESSION-RECOVERABLE`, `RECOVERY-EVENT-DRIVEN`, `RECOVERY-AUTHORITATIVE`, `ROTATION-SIGNAL-DRIVEN`, `ROTATION-SAFE-BOUNDARY`, `CHAT-NONAUTHORITATIVE`, `ASSIGNMENT-IDENTITY` | I, Z, U, AH, AK, BB, BG, BH | formal cold-recovery benchmark with zero conversation context |
+| `G13` Lean Navigable Project Knowledge | `TRUTH-ONE-OWNER`, `LEAN-ORCHESTRATION`, `RECOVERY-AUTHORITATIVE`, `CHAT-NONAUTHORITATIVE`, `ROOT-SPEC-OFF-HOT-PATH` | A, I, Z, AZ, BT, BY | bounded recovery-cost test; stale/duplicate information entropy test |
+| `G14` Repository Readiness, Hygiene & Self-Repair | `BOOTSTRAP-PROPORTIONAL`, `ARTIFACT-FITNESS`, `MUTATION-IDEMPOTENT`, `DRIFT-RECONCILE`, `READY-DONE-SEMANTICS` | A, B, AU, AZ, BS, BT, BU, BE | stale project-system cleanup without parallel duplicate mechanisms |
+| `G15` Proactive Improvement Without Scope Creep | `OUTCOME-STABLE`, `LEAN-ORCHESTRATION`, `ARTIFACT-FITNESS` | Y, AX, AY, BA, BT, BU, CB | improvement proposal/execute/ignore classification benchmark |
+| `G16` Persistent Progress Without Friction | `ANTI-SPIN`, `SYNTHESIZE-WORK`, `MASTER-STOP-CANONICAL`, `WORKER-STOP-LOCAL`, `SELF-EXECUTION-FALLBACK`, `CAPABILITY-NOT-AUTHORITY` | O, Q, R, T, AP, AQ, AW, AX, CN, CQ | decision/tool-step benchmark before first useful action and across local blockers |
 
 ## Traceability rule
 
@@ -40,6 +40,16 @@ Goal ID
 ```
 
 A shorter implementation is not a successful refactor if any link in that chain is lost.
+
+Mechanically enforceable development-time invariants are:
+
+- every canonical Goal ID in `../docs/PROJECT-SPEC.md` appears exactly once in this table;
+- every canonical Rule ID in `RULE-MAP.md` appears in at least one Goal row and no unknown Rule ID is introduced here;
+- every canonical Rule ID has one Rule Map row with one non-empty canonical owner and at least one eval anchor;
+- every explicit Goal/Rule eval anchor resolves to a real unique scenario ID;
+- scenario IDs are unique and contiguous so accidental deletion/duplication is visible.
+
+These checks prove traceability structure only; they do not prove semantic quality, READY, review sufficiency, architecture correctness, or risk judgment.
 
 ## Known project-level coverage gaps
 

--- a/tests/test_validate_skill_phase6.py
+++ b/tests/test_validate_skill_phase6.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Targeted negative/compatibility fixtures for Phase 6 deterministic lint."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "tools" / "validate_skill.py"
+CONTRACT_CHECK = ROOT / "skill" / "scripts" / "contract_check.py"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = load_module("validate_skill", VALIDATOR)
+contract_check = load_module("contract_check_phase6", CONTRACT_CHECK)
+
+
+def expect_failure(name: str, action, contains: str) -> None:
+    try:
+        action()
+    except ValueError as exc:
+        if contains not in str(exc):
+            raise AssertionError(f"{name}: expected error containing {contains!r}, got {exc!r}") from exc
+        print(f"PASS {name}")
+        return
+    raise AssertionError(f"{name}: expected ValueError containing {contains!r}")
+
+
+def write_trace_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+    skill = root / "skill"
+    references = skill / "references"
+    design = root / "design"
+    docs = root / "docs"
+    references.mkdir(parents=True)
+    design.mkdir()
+    docs.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: fixture\ndescription: fixture\n---\n", encoding="utf-8")
+
+    eval_path = references / "eval-scenarios.md"
+    eval_path.write_text("### A. One\n\n### B. Two\n", encoding="utf-8")
+
+    rule_path = design / "RULE-MAP.md"
+    rule_path.write_text(
+        "| Rule ID | Guarantee | Canonical owner | Source anchors | Eval anchors |\n"
+        "|---|---|---|---|---|\n"
+        "| `RULE-ONE` | first | `a.md` | x | A |\n"
+        "| `RULE-TWO` | second | `b.md` | y | B |\n",
+        encoding="utf-8",
+    )
+
+    project_path = docs / "PROJECT-SPEC.md"
+    project_path.write_text(
+        "| ID | Goal |\n|---|---|\n| `G01` | One |\n| `G02` | Two |\n",
+        encoding="utf-8",
+    )
+
+    goal_path = design / "GOAL-MAP.md"
+    goal_path.write_text(
+        "| Goal | Primary rule families / Rule IDs | Existing evaluation anchors | Additional coverage |\n"
+        "|---|---|---|---|\n"
+        "| `G01` One | `RULE-ONE` | A | x |\n"
+        "| `G02` Two | `RULE-TWO` | B | y |\n",
+        encoding="utf-8",
+    )
+    return skill, eval_path, rule_path, goal_path
+
+
+def traceability_tests() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        skill, eval_path, rule_path, goal_path = write_trace_fixture(root)
+        validator.validate_traceability(root, skill)
+        print("PASS traceability-valid")
+
+        eval_path.write_text("### A. One\n\n### A. Duplicate\n", encoding="utf-8")
+        expect_failure(
+            "eval-duplicate",
+            lambda: validator.validate_traceability(root, skill),
+            "Duplicate evaluation scenario IDs",
+        )
+        eval_path.write_text("### A. One\n\n### C. Three\n", encoding="utf-8")
+        expect_failure(
+            "eval-gap",
+            lambda: validator.validate_traceability(root, skill),
+            "Evaluation scenario ID gaps detected: ['B']",
+        )
+        eval_path.write_text("### A. One\n\n### B. Two\n", encoding="utf-8")
+
+        original_rules = rule_path.read_text(encoding="utf-8")
+        rule_path.write_text(original_rules + "| `RULE-ONE` | duplicate | `c.md` | z | A |\n", encoding="utf-8")
+        expect_failure(
+            "rule-duplicate-owner",
+            lambda: validator.validate_traceability(root, skill),
+            "Duplicate canonical Rule rows/owners",
+        )
+        rule_path.write_text(original_rules, encoding="utf-8")
+
+        original_goals = goal_path.read_text(encoding="utf-8")
+        goal_path.write_text(original_goals.replace("`RULE-TWO`", "`RULE-ONE`"), encoding="utf-8")
+        expect_failure(
+            "rule-orphan",
+            lambda: validator.validate_traceability(root, skill),
+            "Canonical Rule IDs are not mapped to any Goal",
+        )
+        goal_path.write_text(original_goals.replace("`RULE-TWO`", "`RULE-THREE`"), encoding="utf-8")
+        expect_failure(
+            "goal-unknown-rule",
+            lambda: validator.validate_traceability(root, skill),
+            "references unknown Rule IDs",
+        )
+        goal_path.write_text(original_goals, encoding="utf-8")
+
+        rule_path.write_text(original_rules.replace("| B |", "| Z |"), encoding="utf-8")
+        expect_failure(
+            "rule-missing-eval",
+            lambda: validator.validate_traceability(root, skill),
+            "references missing evaluation IDs: ['Z']",
+        )
+
+
+def state_tests() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        skill = Path(tmp) / "skill"
+        refs = skill / "references"
+        refs.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "`TaskState.INTEGRATED` `WorkerStatus.READY_FOR_REVIEW` `WriteState.UNKNOWN` "
+            "`DeliveryState.PENDING` `MasterBoundary.BLOCKED`\n",
+            encoding="utf-8",
+        )
+        (refs / "states.md").write_text("`WorkerStatus.STALE_ASSIGNMENT`\n", encoding="utf-8")
+        validator.validate_state_tokens(skill)
+        print("PASS state-valid")
+        (refs / "states.md").write_text("`WorkerStatus.DONE`\n", encoding="utf-8")
+        expect_failure(
+            "state-legacy-token",
+            lambda: validator.validate_state_tokens(skill),
+            "WorkerStatus.DONE",
+        )
+
+
+SHA0 = "a" * 40
+WORKER_BASE = f"""## Goal
+Validate worker identity.
+
+## Scope
+In: deterministic schema.
+Out: qualitative READY judgment.
+
+## Acceptance
+- [ ] Invalid identity combinations fail deterministically.
+
+## Validation
+Run Phase 6 fixtures.
+
+## Dependencies
+none
+
+## Risk / Release
+Risk: LOW
+
+Issue: owner/repo#9
+Assignment ID: 9-g1
+Contract Revision: 1
+Base SHA: {SHA0}
+Assigned Branch: worker/9
+Integration Target: main
+Worker: W9
+Assignment Status: ACTIVE
+Task Risk: LOW
+Start HEAD: {SHA0}
+Project Authority: MANAGED
+Coordination Baseline: STANDARD
+Assurance Level: NORMAL
+"""
+
+
+def contract_result(text: str) -> dict:
+    return contract_check.validate(text, "substantive", True)
+
+
+def expect_contract_failure(name: str, text: str, contains: str) -> None:
+    result = contract_result(text)
+    if result["ok"]:
+        raise AssertionError(f"{name}: expected failure, got {result}")
+    if not any(contains in error for error in result["errors"]):
+        raise AssertionError(f"{name}: missing {contains!r}: {result['errors']}")
+    print(f"PASS {name}")
+
+
+def worker_contract_tests() -> None:
+    valid = contract_result(WORKER_BASE)
+    if not valid["ok"]:
+        raise AssertionError(f"worker-valid: {valid}")
+    print("PASS worker-valid")
+
+    expect_contract_failure(
+        "worker-advisory-authority",
+        WORKER_BASE.replace("Project Authority: MANAGED", "Project Authority: ADVISORY"),
+        "must be MANAGED or AUTONOMOUS_WITH_GATES",
+    )
+    expect_contract_failure(
+        "worker-invalid-baseline",
+        WORKER_BASE.replace("Coordination Baseline: STANDARD", "Coordination Baseline: HIGH_ASSURANCE"),
+        "Coordination Baseline must be LIGHTWEIGHT or STANDARD",
+    )
+    expect_contract_failure(
+        "worker-invalid-assurance",
+        WORKER_BASE.replace("Assurance Level: NORMAL", "Assurance Level: STANDARD"),
+        "Assurance Level must be NORMAL or HIGH_ASSURANCE",
+    )
+    expect_contract_failure(
+        "worker-inactive-dispatch",
+        WORKER_BASE.replace("Assignment Status: ACTIVE", "Assignment Status: COMPLETE"),
+        "Assignment Status must be ACTIVE",
+    )
+    expect_contract_failure(
+        "worker-target-equals-branch",
+        WORKER_BASE.replace("Integration Target: main", "Integration Target: refs/heads/worker/9"),
+        "Assigned Branch must differ from Integration Target",
+    )
+
+
+def main() -> None:
+    traceability_tests()
+    state_tests()
+    worker_contract_tests()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate_skill.py
+++ b/tools/validate_skill.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Repository-local structural validator for GitHub Project Orchestrator."""
+"""Repository-local structural and traceability validator for GitHub Project Orchestrator."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 
 REQUIRED_RUNTIME_PATHS = (
@@ -32,6 +33,56 @@ REQUIRED_DIRECT_ROUTER_TARGETS = tuple(
 FRONTMATTER_RE = re.compile(r"\A---\n(?P<body>.*?)\n---\n", re.DOTALL)
 LINK_RE = re.compile(r"\[[^\]]+\]\((?!https?://|mailto:|#)([^)]+)\)")
 NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+EVAL_HEADING_RE = re.compile(r"^###\s+([A-Z]+)\.\s+", re.MULTILINE)
+PROJECT_GOAL_ROW_RE = re.compile(r"^\|\s*`(G\d{2})`(?:\s+[^|]*)?\s*\|", re.MULTILINE)
+GOAL_ROW_RE = re.compile(
+    r"^\|\s*`(?P<goal>G\d{2})`(?:\s+[^|]*)?\s*\|\s*(?P<rules>.*?)\s*\|\s*(?P<evals>.*?)\s*\|\s*(?P<coverage>.*?)\s*\|\s*$",
+    re.MULTILINE,
+)
+RULE_ROW_RE = re.compile(
+    r"^\|\s*`(?P<rule>[A-Z0-9]+(?:-[A-Z0-9]+)+)`\s*\|\s*(?P<guarantee>.*?)\s*\|\s*(?P<owner>.*?)\s*\|\s*(?P<sources>.*?)\s*\|\s*(?P<evals>.*?)\s*\|\s*$",
+    re.MULTILINE,
+)
+INLINE_RULE_RE = re.compile(r"`([A-Z0-9]+(?:-[A-Z0-9]+)+)`")
+STATE_TOKEN_RE = re.compile(
+    r"\b(?P<namespace>TaskState|WorkerStatus|WriteState|DeliveryState|MasterBoundary)\.(?P<token>[A-Z][A-Z0-9_]*)\b"
+)
+STATE_ENUMS = {
+    "TaskState": {
+        "DRAFT",
+        "BLOCKED",
+        "READY",
+        "IN_PROGRESS",
+        "IN_REVIEW",
+        "CHANGES_REQUESTED",
+        "INTEGRATION_READY",
+        "INTEGRATED",
+        "CANCELLED",
+        "SUPERSEDED",
+        "ROLLED_BACK",
+    },
+    "WorkerStatus": {
+        "STALE_ASSIGNMENT",
+        "MATERIAL_DECISION_REQUIRED",
+        "SCOPE_CHANGE_REQUIRED",
+        "ENVIRONMENT_MISMATCH",
+        "BLOCKED",
+        "READY_FOR_REVIEW",
+    },
+    "WriteState": {"KNOWN", "UNKNOWN"},
+    "DeliveryState": {"NOT_STARTED", "PENDING", "DELIVERED", "FAILED_OR_UNKNOWN"},
+    "MasterBoundary": {
+        "PROJECT_COMPLETE",
+        "APPROVAL_REQUIRED",
+        "MATERIAL_DECISION_REQUIRED",
+        "BLOCKED",
+        "RISK_ESCALATION",
+        "MISSING_CAPABILITY",
+        "NO_READY_WORK",
+        "WRITE_OUTCOME_UNKNOWN",
+        "USER_STOP",
+    },
+}
 
 
 def fail(message: str) -> None:
@@ -110,6 +161,142 @@ def validate_python(skill_dir: Path) -> None:
         compile(source, str(script), "exec")
 
 
+def eval_id_to_int(value: str) -> int:
+    total = 0
+    for char in value:
+        total = total * 26 + (ord(char) - ord("A") + 1)
+    return total
+
+
+def int_to_eval_id(value: int) -> str:
+    chars: list[str] = []
+    while value > 0:
+        value, remainder = divmod(value - 1, 26)
+        chars.append(chr(ord("A") + remainder))
+    return "".join(reversed(chars))
+
+
+def parse_eval_ids(text: str) -> list[str]:
+    return EVAL_HEADING_RE.findall(text)
+
+
+def validate_eval_ids(text: str) -> set[str]:
+    eval_ids = parse_eval_ids(text)
+    if not eval_ids:
+        fail("No evaluation scenario IDs found in references/eval-scenarios.md")
+    duplicates = sorted(value for value, count in Counter(eval_ids).items() if count > 1)
+    if duplicates:
+        fail(f"Duplicate evaluation scenario IDs: {duplicates}")
+
+    numeric = sorted(eval_id_to_int(value) for value in eval_ids)
+    expected = set(range(1, numeric[-1] + 1))
+    actual = set(numeric)
+    missing = [int_to_eval_id(value) for value in sorted(expected - actual)]
+    if missing:
+        fail(f"Evaluation scenario ID gaps detected: {missing}")
+    return set(eval_ids)
+
+
+def parse_eval_anchors(cell: str, context: str) -> set[str]:
+    values = [part.strip().strip("`") for part in cell.split(",") if part.strip()]
+    if not values:
+        fail(f"{context} must include at least one evaluation anchor")
+    invalid = [value for value in values if not re.fullmatch(r"[A-Z]+", value)]
+    if invalid:
+        fail(f"{context} contains invalid evaluation anchor syntax: {invalid}")
+    return set(values)
+
+
+def validate_traceability(repo_root: Path, skill_dir: Path) -> None:
+    rule_map_path = repo_root / "design" / "RULE-MAP.md"
+    goal_map_path = repo_root / "design" / "GOAL-MAP.md"
+    project_spec_path = repo_root / "docs" / "PROJECT-SPEC.md"
+    eval_path = skill_dir / "references" / "eval-scenarios.md"
+    required = (rule_map_path, goal_map_path, project_spec_path, eval_path)
+    missing_files = [str(path.relative_to(repo_root)) for path in required if not path.is_file()]
+    if missing_files:
+        fail(f"Traceability source files are missing: {missing_files}")
+
+    eval_ids = validate_eval_ids(eval_path.read_text(encoding="utf-8"))
+
+    rule_text = rule_map_path.read_text(encoding="utf-8")
+    rule_matches = list(RULE_ROW_RE.finditer(rule_text))
+    if not rule_matches:
+        fail("No canonical Rule rows found in design/RULE-MAP.md")
+    rule_ids = [match.group("rule") for match in rule_matches]
+    duplicate_rules = sorted(value for value, count in Counter(rule_ids).items() if count > 1)
+    if duplicate_rules:
+        fail(f"Duplicate canonical Rule rows/owners in design/RULE-MAP.md: {duplicate_rules}")
+
+    rule_id_set = set(rule_ids)
+    for match in rule_matches:
+        rule_id = match.group("rule")
+        owner = match.group("owner").strip().strip("`").strip()
+        if not owner:
+            fail(f"Rule {rule_id} is missing a canonical owner")
+        anchors = parse_eval_anchors(match.group("evals"), f"Rule {rule_id}")
+        missing_anchors = sorted(anchors - eval_ids, key=eval_id_to_int)
+        if missing_anchors:
+            fail(f"Rule {rule_id} references missing evaluation IDs: {missing_anchors}")
+
+    project_goal_ids = PROJECT_GOAL_ROW_RE.findall(project_spec_path.read_text(encoding="utf-8"))
+    duplicate_project_goals = sorted(value for value, count in Counter(project_goal_ids).items() if count > 1)
+    if duplicate_project_goals:
+        fail(f"Duplicate canonical Goal IDs in docs/PROJECT-SPEC.md: {duplicate_project_goals}")
+    if not project_goal_ids:
+        fail("No canonical Goal IDs found in docs/PROJECT-SPEC.md")
+
+    goal_text = goal_map_path.read_text(encoding="utf-8")
+    goal_matches = list(GOAL_ROW_RE.finditer(goal_text))
+    if not goal_matches:
+        fail("No Goal mapping rows found in design/GOAL-MAP.md")
+    goal_ids = [match.group("goal") for match in goal_matches]
+    duplicate_goal_rows = sorted(value for value, count in Counter(goal_ids).items() if count > 1)
+    if duplicate_goal_rows:
+        fail(f"Duplicate Goal rows in design/GOAL-MAP.md: {duplicate_goal_rows}")
+
+    project_goal_set = set(project_goal_ids)
+    goal_id_set = set(goal_ids)
+    missing_goal_rows = sorted(project_goal_set - goal_id_set)
+    unknown_goal_rows = sorted(goal_id_set - project_goal_set)
+    if missing_goal_rows or unknown_goal_rows:
+        fail(
+            "Goal Map must match canonical project Goal IDs; "
+            f"missing={missing_goal_rows}, unknown={unknown_goal_rows}"
+        )
+
+    mapped_rules: set[str] = set()
+    for match in goal_matches:
+        goal_id = match.group("goal")
+        referenced_rules = set(INLINE_RULE_RE.findall(match.group("rules")))
+        unknown_rules = sorted(referenced_rules - rule_id_set)
+        if unknown_rules:
+            fail(f"Goal {goal_id} references unknown Rule IDs: {unknown_rules}")
+        mapped_rules.update(referenced_rules)
+
+        anchors = parse_eval_anchors(match.group("evals"), f"Goal {goal_id}")
+        missing_anchors = sorted(anchors - eval_ids, key=eval_id_to_int)
+        if missing_anchors:
+            fail(f"Goal {goal_id} references missing evaluation IDs: {missing_anchors}")
+
+    orphan_rules = sorted(rule_id_set - mapped_rules)
+    if orphan_rules:
+        fail(f"Canonical Rule IDs are not mapped to any Goal in design/GOAL-MAP.md: {orphan_rules}")
+
+
+def validate_state_tokens(skill_dir: Path) -> None:
+    for markdown in [skill_dir / "SKILL.md", *sorted((skill_dir / "references").glob("*.md"))]:
+        text = markdown.read_text(encoding="utf-8")
+        for match in STATE_TOKEN_RE.finditer(text):
+            namespace = match.group("namespace")
+            token = match.group("token")
+            if token not in STATE_ENUMS[namespace]:
+                fail(
+                    f"Unknown or legacy namespaced state token in {markdown.relative_to(skill_dir)}: "
+                    f"{namespace}.{token}"
+                )
+
+
 def sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -154,6 +341,8 @@ def main() -> int:
     validate_markdown_links(skill_dir)
     if args.baseline_manifest is None:
         validate_direct_router(skill_dir)
+        validate_state_tokens(skill_dir)
+        validate_traceability(skill_dir.parent, skill_dir)
     validate_python(skill_dir)
     if args.baseline_manifest is not None:
         validate_baseline(skill_dir, args.baseline_manifest.resolve())


### PR DESCRIPTION
Closes #9 when Phase 6 acceptance is complete.

## Goal
Move deterministic invariants into fast repository validation without turning qualitative engineering judgment into brittle scripts.

## Changes
- Make Goal->Rule coverage mechanically complete in `design/GOAL-MAP.md` while preserving canonical definitions in PROJECT-SPEC/RULE-MAP.
- Extend `tools/validate_skill.py` to reject unknown/legacy namespaced runtime states.
- Validate unique/contiguous eval IDs and Goal/Rule eval anchors.
- Reject duplicate canonical Rule rows/owners, unknown Goal->Rule references, orphan Rule IDs, and Goal-map drift from canonical PROJECT-SPEC Goal IDs.
- Keep direct router/reference validation and immutable v1.0.0 baseline behavior intact.
- Add targeted negative fixtures for eval gaps/duplicates, Rule ownership/mapping failures, unknown state tokens, and Worker assignment schema combinations.
- Run Phase 6 fixtures in CI.

## Deterministic-only boundary
The lint verifies structural identity, enum/state vocabulary, traceability links, and Worker schema facts. It does not decide READY quality, architecture, code quality, risk sufficiency, review sufficiency, or product semantics.

## Validation
- `python3 tools/validate_skill.py skill`
- `python3 tests/test_contract_check_phase2.py`
- `python3 tests/test_validate_skill_phase6.py`
- immutable `v1.0.0` baseline verification
- clean runtime/package checks

## Non-goals
- No runtime policy change.
- No subjective architecture/risk/review heuristics in code.
- No Phase 7 benchmark implementation.