### PR TITLE
docs: sync engineering-quality decision graph

### DIFF
--- a/design/DECISION-GRAPHS.md
+++ b/design/DECISION-GRAPHS.md
@@ -184,6 +184,7 @@ Phase 4 implemented progressive event routing in the current runtime. `skill/SKI
 |---|---|
 | new/replacement Master | recovery, identity, authority, capability, outcome |
 | first ownership | root specification, proportional readiness, outcome, source-of-truth |
+| material cross-cutting engineering concern becomes decision-relevant | proportional engineering-quality concern selection + natural implementation/evidence owner; existing scope, risk, authority, review, and release domains remain canonical |
 | before consequential mutation | accepted scope, role, authority, effects, gates, capability, fresh mutable identity |
 | before delegation | contract/READY, assignment identity, Worker envelope, target separation |
 | Worker correction/resume | assignment generation + `CheckpointHEAD` concurrency |


### PR DESCRIPTION
## Outcome
Reconcile the design-only event-to-rule activation mirror with the already-canonical runtime router introduced in v1.1.2.

## Change
- add one `material cross-cutting engineering concern becomes decision-relevant` row to `design/DECISION-GRAPHS.md`;
- point that event at proportional engineering-quality concern selection and the existing natural implementation/evidence owners;
- explicitly preserve existing scope, risk, authority, review, and release ownership.

## Boundary
This is documentation/traceability only. It does not change `skill/`, runtime behavior, state, gates, Goal/Rule ownership, eval semantics, VERSION, or release intent. The installable v1.1.2 Skill remains byte-identical.

## Why
The cold review found that `skill/SKILL.md`, `RULE-MAP`, `GOAL-MAP`, eval coverage, and validator all included the new engineering-quality domain, while this non-canonical design mirror had not been updated with the corresponding event row.