### PR TITLE
Phase A correction: require actual model evidence for optimization claims

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Test runtime equivalence gate
         run: python3 tests/test_runtime_equivalence.py
 
+      - name: Test observable model trial scorer
+        run: python3 tests/test_model_trial_scorer.py
+
       - name: Test release intent decisions
         run: python3 tests/test_release_intent.py
 

--- a/benchmarks/phase7/MODEL-TRIAL-PROTOCOL.md
+++ b/benchmarks/phase7/MODEL-TRIAL-PROTOCOL.md
@@ -17,12 +17,12 @@ The evidence hierarchy is:
 
 ## Trial unit
 
-A trial is a paired execution of the same case against:
+A trial is a paired execution of the same exact case input against:
 
 - immutable baseline representation `v1.2.2@f98e8a242c720931e34aa7c4e8a799090e3d0495`; and
 - one exact candidate representation SHA.
 
-Within a trial suite, keep the model/runtime identity, model settings, available tool surface, case input, and scoring rubric equivalent. Alternate which representation runs first across pairs so order/system warming cannot systematically favor one side.
+Within a trial suite, keep the model/runtime identity, model settings, available tool surface, case input, and scoring rubric equivalent. Each baseline/candidate pair carries the same non-empty `input_fingerprint`, and the scorer rejects mismatched paired inputs. Alternate which representation runs first across pairs so order/system warming cannot systematically favor one side.
 
 Do not inspect, request, store, or score private chain-of-thought. Score only observable behavior and evidence. The scored trial JSON uses a closed schema and rejects undeclared/private-reasoning fields.
 
@@ -31,9 +31,10 @@ Do not inspect, request, store, or score private chain-of-thought. Score only ob
 Each scored run records only:
 
 - `case_id` and unique paired `pair_id`;
+- `input_fingerprint` identifying the exact case input seen by both sides of the pair;
 - exact representation (`baseline` or `candidate`);
 - within-pair order (`1` or `2`);
-- a durable transcript/tool-log reference sufficient for audit;
+- a unique durable transcript/tool-log reference sufficient to audit that run;
 - whether the first/selected next action was correct;
 - any protected-behavior violations;
 - observable steps before the first useful action;
@@ -68,9 +69,10 @@ A candidate cannot pass when any is true:
 - candidate produces any protected-behavior violation in the selection suite;
 - candidate worsens wrong-next-action decisions or any other primary metric in **any required case**;
 - required cases/pairs are incomplete or baseline-first/candidate-first order is materially unbalanced within a case;
+- the two sides of a pair do not have the same exact `input_fingerprint`;
 - baseline and candidate are not tied to exact representation identities;
 - runtime/model/settings/toolset identity is missing;
-- evidence lacks auditable transcript/tool-log references;
+- evidence lacks unique auditable transcript/tool-log references;
 - scored evidence contains undeclared/private-reasoning fields;
 - no material paired improvement is demonstrated.
 
@@ -100,7 +102,7 @@ Therefore final adoption also requires:
 - exact candidate identity;
 - raw evidence availability;
 - semantic/equivalence checks;
-- review of trial construction/order/settings;
+- review of trial construction/order/settings and input-fingerprint provenance;
 - repeat or broader trials when results are marginal, model-specific, or unstable.
 
 If no candidate passes this protocol, the correct Phase B result is **no runtime migration**.

--- a/benchmarks/phase7/MODEL-TRIAL-PROTOCOL.md
+++ b/benchmarks/phase7/MODEL-TRIAL-PROTOCOL.md
@@ -1,0 +1,104 @@
+# Runtime Representation Model-Trial Protocol
+
+Tracking: #35, #36 Contract Revision 2, #37
+
+## Purpose
+
+Use actual comparable model/runtime executions to decide whether a lossless representation change makes the Skill materially easier and more reliable for an LLM to execute.
+
+This protocol exists because a source-grounded policy simulation cannot prove model-performance improvement. If two representations preserve the same semantics, the prescribed correct behavior may legitimately be identical. Manually shortening a synthetic trace would therefore be evidence about the trace author, not evidence that a model executes the candidate better.
+
+The evidence hierarchy is:
+
+1. **Mechanical equivalence** — objective baseline-derived invariants and regression tests.
+2. **Source-grounded policy simulation** — expected protected behavior and diagnostic structural/context deltas; never practical-performance proof by itself.
+3. **Actual model/runtime A/B trials** — the only evidence lane that may satisfy the practical-improvement requirement.
+4. **Semantic/high-assurance review** — checks that measured gains did not hide behavior loss, benchmark gaming, or maintenance/routing regressions.
+
+## Trial unit
+
+A trial is a paired execution of the same case against:
+
+- immutable baseline representation `v1.2.2@f98e8a242c720931e34aa7c4e8a799090e3d0495`; and
+- one exact candidate representation SHA.
+
+Within a trial suite, keep the model/runtime identity, model settings, available tool surface, case input, and scoring rubric equivalent. Alternate which representation runs first so order/system warming cannot systematically favor one side.
+
+Do not inspect, request, store, or score private chain-of-thought. Score only observable behavior and evidence.
+
+## Required observable fields
+
+Each run records:
+
+- `case_id` and unique paired `pair_id`;
+- exact representation (`baseline` or `candidate`);
+- within-pair order (`1` or `2`);
+- a durable transcript/tool-log reference sufficient for audit;
+- whether the first/selected next action was correct;
+- any protected-behavior violations;
+- observable steps before the first useful action;
+- unnecessary user questions/confirmations;
+- unnecessary actions/tool operations;
+- unnecessary runtime-reference loads;
+- whether a premature terminal response required a manual `continue`.
+
+Optional latency/token fields may be recorded when measured comparably, but they are diagnostic by default because provider/runtime scheduling and tokenizer differences can confound them.
+
+## Required case coverage
+
+Use the machine-readable contract in `model-trial-cases.json`. It includes the eight current representation-comparison classes:
+
+- hot FAST Master path;
+- consequential mutation/authority path;
+- Worker dispatch/resume;
+- cold Master recovery;
+- review/integration freshness;
+- pending external job continuation;
+- integration versus delivery;
+- namespace/effect isolation.
+
+The default selection suite requires at least three paired runs per case. More runs are appropriate when results are noisy or near the decision boundary.
+
+## Hard gates
+
+A candidate cannot pass when any is true:
+
+- candidate produces any protected-behavior violation in the selection suite;
+- candidate has more wrong next-action decisions than baseline;
+- candidate materially worsens a gated observable friction metric in aggregate;
+- required cases/pairs are incomplete or baseline/candidate order is materially unbalanced;
+- baseline and candidate are not tied to exact representation identities;
+- runtime/model/settings/toolset identity is missing;
+- evidence lacks auditable transcript/tool-log references;
+- no material paired improvement is demonstrated.
+
+A better token count, prettier table, shorter file, or hand-authored source trace cannot compensate for one of these failures.
+
+## Material improvement rule
+
+For paired observable metrics, the deterministic scorer uses an exact one-sided sign test over non-tied pairs. By default, `alpha = 0.05`.
+
+The candidate must:
+
+1. pass every hard gate; and
+2. show statistically directional paired improvement (`p <= alpha`) on at least one primary metric:
+   - protected-violation count;
+   - wrong-next-action count;
+   - observable steps before first useful action; or
+   - composite avoidable events = unnecessary questions + unnecessary actions + unnecessary reference loads + manual-continue events.
+
+The sign test deliberately ignores improvement magnitude when testing direction, so the scorer also reports aggregate deltas for review. Final selection still checks whether the measured gain is operationally meaningful enough to repay maintenance/routing complexity.
+
+## What the scorer proves and does not prove
+
+A passing score proves only that the supplied paired observable trial records satisfy this protocol and show a directional improvement without the configured protected regressions. It does not prove that transcripts are authentic, that a provider/model implementation is unbiased, or that every future model/runtime will improve.
+
+Therefore final adoption also requires:
+
+- exact candidate identity;
+- raw evidence availability;
+- semantic/equivalence checks;
+- review of trial construction/order/settings;
+- repeat or broader trials when results are marginal, model-specific, or unstable.
+
+If no candidate passes this protocol, the correct Phase B result is **no runtime migration**.

--- a/benchmarks/phase7/MODEL-TRIAL-PROTOCOL.md
+++ b/benchmarks/phase7/MODEL-TRIAL-PROTOCOL.md
@@ -46,7 +46,9 @@ Optional latency/token measurements may be captured in a **separate diagnostic a
 
 ## Required case coverage
 
-Use the machine-readable contract in `model-trial-cases.json`. It includes the eight current representation-comparison classes:
+`runtime-optimization-scenarios.json` is the single semantic owner for the representation-comparison cases, including each case's protected behavior and eval anchors. `model-trial-cases.json` is only the actual-model scoring/selection manifest: it references that canonical semantic contract and selects the same eight case IDs without duplicating their meaning.
+
+The selected cases cover:
 
 - hot FAST Master path;
 - consequential mutation/authority path;

--- a/benchmarks/phase7/MODEL-TRIAL-PROTOCOL.md
+++ b/benchmarks/phase7/MODEL-TRIAL-PROTOCOL.md
@@ -22,13 +22,13 @@ A trial is a paired execution of the same case against:
 - immutable baseline representation `v1.2.2@f98e8a242c720931e34aa7c4e8a799090e3d0495`; and
 - one exact candidate representation SHA.
 
-Within a trial suite, keep the model/runtime identity, model settings, available tool surface, case input, and scoring rubric equivalent. Alternate which representation runs first so order/system warming cannot systematically favor one side.
+Within a trial suite, keep the model/runtime identity, model settings, available tool surface, case input, and scoring rubric equivalent. Alternate which representation runs first across pairs so order/system warming cannot systematically favor one side.
 
-Do not inspect, request, store, or score private chain-of-thought. Score only observable behavior and evidence.
+Do not inspect, request, store, or score private chain-of-thought. Score only observable behavior and evidence. The scored trial JSON uses a closed schema and rejects undeclared/private-reasoning fields.
 
 ## Required observable fields
 
-Each run records:
+Each scored run records only:
 
 - `case_id` and unique paired `pair_id`;
 - exact representation (`baseline` or `candidate`);
@@ -42,7 +42,7 @@ Each run records:
 - unnecessary runtime-reference loads;
 - whether a premature terminal response required a manual `continue`.
 
-Optional latency/token fields may be recorded when measured comparably, but they are diagnostic by default because provider/runtime scheduling and tokenizer differences can confound them.
+Optional latency/token measurements may be captured in a **separate diagnostic artifact** when measured comparably, but they are not fields in the scored trial JSON and are diagnostic by default because provider/runtime scheduling and tokenizer differences can confound them.
 
 ## Required case coverage
 
@@ -64,12 +64,12 @@ The default selection suite requires at least three paired runs per case. More r
 A candidate cannot pass when any is true:
 
 - candidate produces any protected-behavior violation in the selection suite;
-- candidate has more wrong next-action decisions than baseline;
-- candidate materially worsens a gated observable friction metric in aggregate;
-- required cases/pairs are incomplete or baseline/candidate order is materially unbalanced;
+- candidate worsens wrong-next-action decisions or any other primary metric in **any required case**;
+- required cases/pairs are incomplete or baseline-first/candidate-first order is materially unbalanced within a case;
 - baseline and candidate are not tied to exact representation identities;
 - runtime/model/settings/toolset identity is missing;
 - evidence lacks auditable transcript/tool-log references;
+- scored evidence contains undeclared/private-reasoning fields;
 - no material paired improvement is demonstrated.
 
 A better token count, prettier table, shorter file, or hand-authored source trace cannot compensate for one of these failures.
@@ -87,7 +87,7 @@ The candidate must:
    - observable steps before first useful action; or
    - composite avoidable events = unnecessary questions + unnecessary actions + unnecessary reference loads + manual-continue events.
 
-The sign test deliberately ignores improvement magnitude when testing direction, so the scorer also reports aggregate deltas for review. Final selection still checks whether the measured gain is operationally meaningful enough to repay maintenance/routing complexity.
+The sign test deliberately ignores improvement magnitude when testing direction, so the scorer also reports aggregate totals for review. Final selection still checks whether the measured gain is operationally meaningful enough to repay maintenance/routing complexity.
 
 ## What the scorer proves and does not prove
 

--- a/benchmarks/phase7/README.md
+++ b/benchmarks/phase7/README.md
@@ -12,8 +12,9 @@ This lane does not rewrite the historical `v1.0.0 -> v1.1.0` evidence above. It 
 
 - `runtime-optimization-baseline.json` — exact baseline identity and the mechanical semantic surfaces/predicate owners checked by `tools/check_runtime_equivalence.py`;
 - `traces-v1.2.2.json` — source-grounded v1.2.2 policy-simulation traces for the existing eight Phase 7 scenarios;
-- `runtime-optimization-scenarios.json` — the minimum representation-comparison classes, including the hot FAST path, consequential authority path, Worker resume, cold recovery, review freshness, pending dependency continuation, integration/delivery separation, and namespace/effect isolation;
-- `MODEL-TRIAL-PROTOCOL.md` and `model-trial-cases.json` — the observable paired actual-model/runtime A/B contract that is the only benchmark lane eligible to prove practical representation improvement;
+- `runtime-optimization-scenarios.json` — the single semantic owner for the representation-comparison classes, protected behavior, eval anchors, and diagnostic measurements;
+- `MODEL-TRIAL-PROTOCOL.md` — the observable paired actual-model/runtime A/B protocol that is the only benchmark lane eligible to prove practical representation improvement;
+- `model-trial-cases.json` — the non-semantic scoring/selection manifest that references `runtime-optimization-scenarios.json` and selects the same canonical case IDs without duplicating their meaning;
 - `tools/score_model_trials.py` — the deterministic scorer for supplied paired observable A/B records;
 - `../../tests/test_runtime_equivalence.py` and `../../tests/test_model_trial_scorer.py` — adversarial fixtures for the mechanical and real-trial evidence gates.
 
@@ -60,6 +61,8 @@ Historical Phase 7 legitimately uses its source-grounded traces to document the 
 
 `MODEL-TRIAL-PROTOCOL.md` defines the evidence needed for a current representation-optimization claim. Each paired run compares the exact immutable v1.2.2 representation and one exact candidate on the same case under equivalent runtime identity/settings/tool availability. Only observable run behavior is scored.
 
+`runtime-optimization-scenarios.json` remains the semantic owner for those cases. `model-trial-cases.json` only selects their IDs and defines scoring parameters such as minimum pair count, primary metrics, and sign-test alpha; CI requires both manifests to remain aligned.
+
 Primary metrics are:
 
 - protected-behavior violation count;
@@ -78,13 +81,13 @@ Optional token/latency measurements may be kept in a separate diagnostic artifac
 - `traces-current.json` — historical refactored source-grounded traces pinned to immutable prerelease commit `53182d5db086eef98ebaba757bb820b86e465845`; the filename is phase-relative and does not mean the traces follow later release candidates.
 - `runtime-optimization-baseline.json` — immutable v1.2.2 representation-comparison baseline configuration.
 - `traces-v1.2.2.json` — immutable v1.2.2 source-grounded policy-simulation baseline for representation candidates.
-- `runtime-optimization-scenarios.json` — current representation-comparison semantic/diagnostic case contract.
+- `runtime-optimization-scenarios.json` — canonical representation-comparison semantic/diagnostic case contract.
 - `MODEL-TRIAL-PROTOCOL.md` — actual model/runtime A/B evidence protocol.
-- `model-trial-cases.json` — machine-readable actual model/runtime case and acceptance contract.
+- `model-trial-cases.json` — scoring/selection manifest referencing the canonical semantic case contract; not a second semantic owner.
 - `RESULTS.md` — checked-in historical Phase 7 interpretation and acceptance result.
 - `LIVE-EVIDENCE.md` — real GitHub delivery evidence from integrated refactor phases.
 - `../../tests/test_phase7_benchmark.py` — adversarial fixtures for historical and source-grounded representation-comparison behavior.
-- `../../tests/test_runtime_equivalence.py` — adversarial fixtures for the immutable runtime-equivalence gate.
+- `../../tests/test_runtime_equivalence.py` — adversarial fixtures for the immutable runtime-equivalence gate and semantic-case manifest alignment.
 - `../../tests/test_model_trial_scorer.py` — adversarial fixtures for observable paired model/runtime evidence scoring.
 
 ## Run

--- a/benchmarks/phase7/README.md
+++ b/benchmarks/phase7/README.md
@@ -12,18 +12,24 @@ This lane does not rewrite the historical `v1.0.0 -> v1.1.0` evidence above. It 
 
 - `runtime-optimization-baseline.json` — exact baseline identity and the mechanical semantic surfaces/predicate owners checked by `tools/check_runtime_equivalence.py`;
 - `traces-v1.2.2.json` — source-grounded v1.2.2 policy-simulation traces for the existing eight Phase 7 scenarios;
-- `runtime-optimization-scenarios.json` — the minimum comparison classes for Phase B, including the hot FAST path, consequential authority path, Worker resume, cold recovery, review freshness, pending dependency continuation, integration/delivery separation, and namespace/effect isolation;
-- `../../tests/test_runtime_equivalence.py` — adversarial fixtures proving that Rule/owner/Goal/state/router/eval/predicate loss is rejected.
+- `runtime-optimization-scenarios.json` — the minimum representation-comparison classes, including the hot FAST path, consequential authority path, Worker resume, cold recovery, review freshness, pending dependency continuation, integration/delivery separation, and namespace/effect isolation;
+- `MODEL-TRIAL-PROTOCOL.md` and `model-trial-cases.json` — the observable paired actual-model/runtime A/B contract that is the only benchmark lane eligible to prove practical representation improvement;
+- `tools/score_model_trials.py` — the deterministic scorer for supplied paired observable A/B records;
+- `../../tests/test_runtime_equivalence.py` and `../../tests/test_model_trial_scorer.py` — adversarial fixtures for the mechanical and real-trial evidence gates.
 
-`tools/score_phase7_benchmark.py --comparison-mode candidate` compares two full-SHA-pinned source-grounded trace sets. Candidate acceptance is stricter than simple equivalence: protected behavior must stay clean, every measured friction field must be non-worse, and at least one material source-grounded decision-cost field must improve. An identical baseline/candidate pair is deliberately **not** an optimization win.
+### Evidence roles are intentionally separate
 
-The source-grounded lane still does **not** prove actual LLM latency, comprehension quality, or cross-model reliability. Phase B must add comparable model/runtime trial evidence before a representation change is selected for migration. The mechanical equivalence checker likewise proves only objective representation invariants; semantic prose/judgment equivalence remains a review/evaluation responsibility.
+`tools/score_phase7_benchmark.py --comparison-mode candidate` compares two full-SHA-pinned **source-grounded policy simulations**. In the representation-optimization program this mode checks protected behavior and reports diagnostic friction/context deltas only. It always reports `optimization_claim_eligible: false`. An identical baseline/candidate trace can therefore be valid, and a manually shortened candidate trace can be diagnostically smaller, without either result proving that an LLM is faster, more accurate, or less error-prone.
 
-## What this benchmark measures
+Practical improvement may be accepted only from the separate paired actual-model/runtime A/B lane described in `MODEL-TRIAL-PROTOCOL.md`. That lane keeps model/runtime/settings/toolset identity fixed, alternates representation order within pairs, scores only observable behavior, requires auditable transcript/tool-log references, hard-fails protected regressions, and requires a material paired improvement. It never requests or scores private chain-of-thought.
 
-The benchmark uses eight representative project traces covering small, medium, large/multi-repository, cold recovery, bounded delegation, review drift, production release, and local-blocker flow. Each scenario declares observable required behavior, proportional coordination, permitted human confirmation/artifact counts, delivery requirements, and the expected terminal boundary.
+The mechanical equivalence checker likewise proves only objective representation invariants; semantic prose/judgment equivalence remains a review/evaluation responsibility.
 
-`tools/score_phase7_benchmark.py` scores both baseline and current traces for:
+## Historical source-grounded benchmark measures
+
+The historical benchmark uses eight representative project traces covering small, medium, large/multi-repository, cold recovery, bounded delegation, review drift, production release, and local-blocker flow. Each scenario declares observable required behavior, proportional coordination, permitted human confirmation/artifact counts, delivery requirements, and the expected terminal boundary.
+
+`tools/score_phase7_benchmark.py` scores source-grounded traces for:
 
 - protected-behavior violations;
 - steps before the first useful engineering action;
@@ -40,28 +46,46 @@ The benchmark uses eight representative project traces covering small, medium, l
 
 The scorer treats unsafe shortcuts, hidden human work, stale integration, missing delivery verification, wrong stop boundaries, overweight coordination, and missing required controls as failures. It never gives safety credit in exchange for lower friction.
 
-## Evidence types and limitation
+## Evidence types and limitations
 
-The A/B traces in this phase are **source-grounded policy simulations**. They are produced by applying the pinned runtime instructions to fixed scenarios and recording the prescribed/selected execution path. They are reproducible and auditable against the cited runtime paths, but they are not independent multi-model trials and do not measure wall-clock model latency.
+### Source-grounded policy simulation
 
-The scorer rejects floating/malformed provenance and, when run with `--repo-root`, verifies every declared `ref:path` directly from Git. This prevents later `main` drift from silently changing the historical Phase 7 evidence. Pinning to a reachable immutable release commit also prevents ordinary branch cleanup from making valid historical provenance unreadable in CI.
+The source-grounded traces are produced by applying pinned runtime instructions to fixed scenarios and recording the prescribed/selected execution path. They are reproducible and auditable against cited runtime paths, but they are not independent model trials and do not measure actual model comprehension, routing reliability, latency, or execution quality.
 
-That limitation is deliberate and visible. Phase 7 uses these traces to prove that the refactored policy surface can preserve protected behavior while reducing prescribed operational work. `LIVE-EVIDENCE.md` separately records real repository delivery evidence. Regression scenario `BC` in `skill/references/eval-scenarios.md` covers the independent-review handoff semantics; Phase 8 then exercised independent review on a real release candidate rather than treating the synthetic scenario as sufficient evidence by itself.
+The scorer rejects floating/malformed provenance and, when run with `--repo-root`, verifies every declared `ref:path` directly from Git. This prevents later `main` drift from silently changing evidence. For representation candidates, trace friction differences are diagnostics only and cannot satisfy the program's practical-improvement requirement.
 
-Token/word/line size is diagnostic only. The scorer reports pinned baseline/current `SKILL.md` entrypoint size from Git when run with `--repo-root`, but entrypoint shrinkage cannot compensate for a protected-behavior regression.
+Historical Phase 7 legitimately uses its source-grounded traces to document the prescribed operational effects of the v1.1.0 refactor. That historical result is preserved as historical evidence and is not retroactively reinterpreted as actual model-performance proof.
+
+### Actual model/runtime paired A/B evidence
+
+`MODEL-TRIAL-PROTOCOL.md` defines the evidence needed for a current representation-optimization claim. Each paired run compares the exact immutable v1.2.2 representation and one exact candidate on the same case under equivalent runtime identity/settings/tool availability. Only observable run behavior is scored.
+
+Primary metrics are:
+
+- protected-behavior violation count;
+- wrong next-action decision count;
+- observable steps before first useful action;
+- composite avoidable events: unnecessary questions + unnecessary actions + unnecessary reference loads + manual-continue events.
+
+The default contract requires at least three pairs per case, balanced order within one run where practical, zero candidate protected violations, no per-case worsening on a primary metric, and at least one directional paired improvement meeting the configured exact one-sided sign-test threshold. Passing the scorer still requires evidence review of transcript authenticity, trial construction, model/runtime identity, and operational significance before migration.
+
+Optional token/latency fields may be recorded when measured comparably, but they are diagnostic by default. Token/word/line reduction cannot compensate for a correctness/safety regression and cannot establish an optimization win by itself.
 
 ## Files
 
-- `scenarios.json` — fixed scenario contract and Goal coverage.
-- `traces-v1.0.0.json` — baseline source-grounded traces pinned to `v1.0.0`.
+- `scenarios.json` — fixed historical Phase 7 scenario contract and Goal coverage.
+- `traces-v1.0.0.json` — historical baseline source-grounded traces pinned to `v1.0.0`.
 - `traces-current.json` — historical refactored source-grounded traces pinned to immutable prerelease commit `53182d5db086eef98ebaba757bb820b86e465845`; the filename is phase-relative and does not mean the traces follow later release candidates.
 - `runtime-optimization-baseline.json` — immutable v1.2.2 representation-comparison baseline configuration.
-- `traces-v1.2.2.json` — immutable v1.2.2 source-grounded policy-simulation baseline for future representation candidates.
-- `runtime-optimization-scenarios.json` — current representation-comparison case contract; it supplements rather than replaces the historical eight-scenario schema.
+- `traces-v1.2.2.json` — immutable v1.2.2 source-grounded policy-simulation baseline for representation candidates.
+- `runtime-optimization-scenarios.json` — current representation-comparison semantic/diagnostic case contract.
+- `MODEL-TRIAL-PROTOCOL.md` — actual model/runtime A/B evidence protocol.
+- `model-trial-cases.json` — machine-readable actual model/runtime case and acceptance contract.
 - `RESULTS.md` — checked-in historical Phase 7 interpretation and acceptance result.
 - `LIVE-EVIDENCE.md` — real GitHub delivery evidence from integrated refactor phases.
-- `../../tests/test_phase7_benchmark.py` — adversarial negative fixtures for historical and current candidate-comparison scorer behavior.
-- `../../tests/test_runtime_equivalence.py` — adversarial negative fixtures for the immutable runtime-equivalence gate.
+- `../../tests/test_phase7_benchmark.py` — adversarial fixtures for historical and source-grounded representation-comparison behavior.
+- `../../tests/test_runtime_equivalence.py` — adversarial fixtures for the immutable runtime-equivalence gate.
+- `../../tests/test_model_trial_scorer.py` — adversarial fixtures for observable paired model/runtime evidence scoring.
 
 ## Run
 
@@ -88,7 +112,7 @@ python3 tools/score_phase7_benchmark.py \
 python3 tools/check_runtime_equivalence.py --repo-root .
 ```
 
-Compare a future candidate trace set only after it is pinned to the exact candidate SHA:
+Compare a future candidate source-grounded trace set for protected behavior and diagnostics only:
 
 ```bash
 python3 tools/score_phase7_benchmark.py \
@@ -99,11 +123,20 @@ python3 tools/score_phase7_benchmark.py \
   --repo-root .
 ```
 
+Score actual paired model/runtime evidence after Phase B has produced an exact candidate and auditable run records:
+
+```bash
+python3 tools/score_model_trials.py \
+  --cases benchmarks/phase7/model-trial-cases.json \
+  --trials <actual-model-trials.json>
+```
+
 Run adversarial fixtures:
 
 ```bash
 python3 tests/test_phase7_benchmark.py
 python3 tests/test_runtime_equivalence.py
+python3 tests/test_model_trial_scorer.py
 ```
 
-A historical passing score still requires zero protected-behavior violations in both historical trace sets, full `G01`-`G16` scenario coverage, correct proportional coordination, and the original friction reductions. A representation candidate additionally must preserve the immutable v1.2.2 semantic gate and demonstrate a material comparable improvement; source-grounded evidence alone is not sufficient proof of actual model performance.
+A historical passing score still requires zero protected-behavior violations in both historical trace sets, full `G01`-`G16` scenario coverage, correct proportional coordination, and the historical friction result. A current representation candidate must preserve the immutable v1.2.2 semantic/protected-behavior gate **and separately pass actual comparable model/runtime A/B evidence before any practical optimization claim or migration is accepted**.

--- a/benchmarks/phase7/README.md
+++ b/benchmarks/phase7/README.md
@@ -21,7 +21,7 @@ This lane does not rewrite the historical `v1.0.0 -> v1.1.0` evidence above. It 
 
 `tools/score_phase7_benchmark.py --comparison-mode candidate` compares two full-SHA-pinned **source-grounded policy simulations**. In the representation-optimization program this mode checks protected behavior and reports diagnostic friction/context deltas only. It always reports `optimization_claim_eligible: false`. An identical baseline/candidate trace can therefore be valid, and a manually shortened candidate trace can be diagnostically smaller, without either result proving that an LLM is faster, more accurate, or less error-prone.
 
-Practical improvement may be accepted only from the separate paired actual-model/runtime A/B lane described in `MODEL-TRIAL-PROTOCOL.md`. That lane keeps model/runtime/settings/toolset identity fixed, alternates representation order within pairs, scores only observable behavior, requires auditable transcript/tool-log references, hard-fails protected regressions, and requires a material paired improvement. It never requests or scores private chain-of-thought.
+Practical improvement may be accepted only from the separate paired actual-model/runtime A/B lane described in `MODEL-TRIAL-PROTOCOL.md`. That lane keeps model/runtime/settings/toolset identity fixed, alternates which representation runs first across pairs, scores only observable behavior, requires auditable transcript/tool-log references, hard-fails protected regressions, and requires a material paired improvement. It never requests or scores private chain-of-thought.
 
 The mechanical equivalence checker likewise proves only objective representation invariants; semantic prose/judgment equivalence remains a review/evaluation responsibility.
 
@@ -67,9 +67,9 @@ Primary metrics are:
 - observable steps before first useful action;
 - composite avoidable events: unnecessary questions + unnecessary actions + unnecessary reference loads + manual-continue events.
 
-The default contract requires at least three pairs per case, balanced order within one run where practical, zero candidate protected violations, no per-case worsening on a primary metric, and at least one directional paired improvement meeting the configured exact one-sided sign-test threshold. Passing the scorer still requires evidence review of transcript authenticity, trial construction, model/runtime identity, and operational significance before migration.
+The default contract requires at least three pairs per case, balanced baseline-first/candidate-first order within each case, zero candidate protected violations, no per-case worsening on a primary metric, and at least one directional paired improvement meeting the configured exact one-sided sign-test threshold. Passing the scorer still requires evidence review of transcript authenticity, trial construction, model/runtime identity, and operational significance before migration.
 
-Optional token/latency fields may be recorded when measured comparably, but they are diagnostic by default. Token/word/line reduction cannot compensate for a correctness/safety regression and cannot establish an optimization win by itself.
+Optional token/latency measurements may be kept in a separate diagnostic artifact when measured comparably; the scored trial JSON intentionally has a closed observable schema and does not accept them. Token/word/line reduction cannot compensate for a correctness/safety regression and cannot establish an optimization win by itself.
 
 ## Files
 

--- a/benchmarks/phase7/model-trial-cases.json
+++ b/benchmarks/phase7/model-trial-cases.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "suite_id": "lossless-runtime-representation-v1",
+  "baseline_ref": "f98e8a242c720931e34aa7c4e8a799090e3d0495",
+  "minimum_pairs_per_case": 3,
+  "sign_test_alpha": 0.05,
+  "evidence_kind": "actual-model-runtime-ab",
+  "primary_metrics": [
+    "protected_violation_count",
+    "decision_error",
+    "steps_to_first_useful_action",
+    "avoidable_events"
+  ],
+  "observable_only": true,
+  "cases": [
+    {
+      "id": "hot-fast-master-path",
+      "class": "hot-path",
+      "protect": [
+        "reuse still-valid stable dimensions rather than ceremonially reclassifying them",
+        "FAST remains available for bounded reversible Master work",
+        "no unnecessary confirmation or persistent contract is introduced"
+      ]
+    },
+    {
+      "id": "consequential-mutation-authority-path",
+      "class": "gate",
+      "protect": [
+        "actual deterministic effects are classified before mutation",
+        "multi-effect obligations remain a union",
+        "capability or a scoped grant never broadens unrelated Authority"
+      ]
+    },
+    {
+      "id": "worker-dispatch-and-resume",
+      "class": "delegation",
+      "protect": [
+        "Worker assignment remains bounded and complete",
+        "StartHEAD and CheckpointHEAD remain distinct",
+        "Worker stop never automatically becomes Master stop"
+      ]
+    },
+    {
+      "id": "cold-master-recovery",
+      "class": "recovery",
+      "protect": [
+        "authoritative state outranks old chat",
+        "Authority and effective coordination/assurance recover losslessly",
+        "ordinary planned transitions do not restart broad recovery"
+      ]
+    },
+    {
+      "id": "review-integration-freshness",
+      "class": "review",
+      "protect": [
+        "review remains bound to exact current effective change",
+        "material drift invalidates affected approval",
+        "incomplete independent review cannot issue an overall verdict"
+      ]
+    },
+    {
+      "id": "pending-external-job-continuation",
+      "class": "flow",
+      "protect": [
+        "independent useful work proceeds before waiting",
+        "healthy pending state is not failure or NO_READY_WORK",
+        "terminal response is not allowed while executable outcome-linked work remains"
+      ]
+    },
+    {
+      "id": "integration-versus-delivery",
+      "class": "release",
+      "protect": [
+        "integration never implies delivered",
+        "delivery target and delivery state remain independent",
+        "wrong or unknown production artifact identity cannot be called delivered"
+      ]
+    },
+    {
+      "id": "namespace-and-effect-isolation",
+      "class": "adversarial",
+      "protect": [
+        "TaskState.BLOCKED, WorkerStatus.BLOCKED, WriteState.UNKNOWN, and MasterBoundary remain independent",
+        "multi-effect actions retain every independently applicable obligation",
+        "matching token text never creates a cross-namespace edge"
+      ]
+    }
+  ]
+}

--- a/benchmarks/phase7/model-trial-cases.json
+++ b/benchmarks/phase7/model-trial-cases.json
@@ -2,6 +2,7 @@
   "schema_version": 1,
   "suite_id": "lossless-runtime-representation-v1",
   "baseline_ref": "f98e8a242c720931e34aa7c4e8a799090e3d0495",
+  "semantic_case_contract": "benchmarks/phase7/runtime-optimization-scenarios.json",
   "minimum_pairs_per_case": 3,
   "sign_test_alpha": 0.05,
   "evidence_kind": "actual-model-runtime-ab",
@@ -12,78 +13,14 @@
     "avoidable_events"
   ],
   "observable_only": true,
-  "cases": [
-    {
-      "id": "hot-fast-master-path",
-      "class": "hot-path",
-      "protect": [
-        "reuse still-valid stable dimensions rather than ceremonially reclassifying them",
-        "FAST remains available for bounded reversible Master work",
-        "no unnecessary confirmation or persistent contract is introduced"
-      ]
-    },
-    {
-      "id": "consequential-mutation-authority-path",
-      "class": "gate",
-      "protect": [
-        "actual deterministic effects are classified before mutation",
-        "multi-effect obligations remain a union",
-        "capability or a scoped grant never broadens unrelated Authority"
-      ]
-    },
-    {
-      "id": "worker-dispatch-and-resume",
-      "class": "delegation",
-      "protect": [
-        "Worker assignment remains bounded and complete",
-        "StartHEAD and CheckpointHEAD remain distinct",
-        "Worker stop never automatically becomes Master stop"
-      ]
-    },
-    {
-      "id": "cold-master-recovery",
-      "class": "recovery",
-      "protect": [
-        "authoritative state outranks old chat",
-        "Authority and effective coordination/assurance recover losslessly",
-        "ordinary planned transitions do not restart broad recovery"
-      ]
-    },
-    {
-      "id": "review-integration-freshness",
-      "class": "review",
-      "protect": [
-        "review remains bound to exact current effective change",
-        "material drift invalidates affected approval",
-        "incomplete independent review cannot issue an overall verdict"
-      ]
-    },
-    {
-      "id": "pending-external-job-continuation",
-      "class": "flow",
-      "protect": [
-        "independent useful work proceeds before waiting",
-        "healthy pending state is not failure or NO_READY_WORK",
-        "terminal response is not allowed while executable outcome-linked work remains"
-      ]
-    },
-    {
-      "id": "integration-versus-delivery",
-      "class": "release",
-      "protect": [
-        "integration never implies delivered",
-        "delivery target and delivery state remain independent",
-        "wrong or unknown production artifact identity cannot be called delivered"
-      ]
-    },
-    {
-      "id": "namespace-and-effect-isolation",
-      "class": "adversarial",
-      "protect": [
-        "TaskState.BLOCKED, WorkerStatus.BLOCKED, WriteState.UNKNOWN, and MasterBoundary remain independent",
-        "multi-effect actions retain every independently applicable obligation",
-        "matching token text never creates a cross-namespace edge"
-      ]
-    }
+  "case_ids": [
+    "hot-fast-master-path",
+    "consequential-mutation-authority-path",
+    "worker-dispatch-and-resume",
+    "cold-master-recovery",
+    "review-integration-freshness",
+    "pending-external-job-continuation",
+    "integration-versus-delivery",
+    "namespace-and-effect-isolation"
   ]
 }

--- a/benchmarks/phase7/runtime-optimization-scenarios.json
+++ b/benchmarks/phase7/runtime-optimization-scenarios.json
@@ -1,12 +1,14 @@
 {
   "schema_version": 1,
-  "purpose": "Comparable v1.2.2-baseline versus candidate decision-representation trials inside the existing Phase 7 benchmark system.",
+  "purpose": "Semantic/protected-behavior and diagnostic comparison contract for v1.2.2-baseline versus candidate decision representations inside the existing Phase 7 benchmark system; practical improvement requires separate actual-model-runtime A/B evidence.",
   "baseline_ref": "f98e8a242c720931e34aa7c4e8a799090e3d0495",
   "evidence_policy": {
     "protected_behavior_is_hard_gate": true,
     "token_or_line_count_is_success_metric": false,
     "source_grounded_trace_is_model_performance_proof": false,
-    "candidate_requires_material_improvement": true
+    "source_grounded_friction_is_diagnostic_only": true,
+    "practical_improvement_requires_actual_model_runtime_ab": true,
+    "candidate_requires_material_improvement_before_migration": true
   },
   "comparison_cases": [
     {

--- a/design/LOSSLESS-RUNTIME-OPTIMIZATION.md
+++ b/design/LOSSLESS-RUNTIME-OPTIMIZATION.md
@@ -10,19 +10,19 @@ Final proof/integration task: #39
 
 Optimize **how** the runtime expresses the existing orchestration semantics so an LLM can select and execute the correct path with less inference, reconstruction, irrelevant context traversal, and activation error.
 
-This program is intentionally different from adding, removing, or changing orchestration policy. The candidate runtime is acceptable only when the current semantic contract is preserved losslessly and comparable evidence shows a material execution benefit.
+This program is intentionally different from adding, removing, or changing orchestration policy. The candidate runtime is acceptable only when the current semantic contract is preserved losslessly and comparable **actual model/runtime A/B evidence** shows a material execution benefit.
 
 The optimization target is:
 
 ```text
-Semantic behavior:       IDENTICAL for protected baseline requirements
-Safety/correctness:      >= baseline
-Decision quality:        >= baseline
-Practical friction:      < baseline on at least one material comparable metric
+Semantic behavior:        IDENTICAL for protected baseline requirements
+Safety/correctness:       >= baseline
+Decision quality:         >= baseline on comparable actual model/runtime trials
+Practical friction:       < baseline on at least one material observable paired metric
 Maintenance/routing cost: no material net regression
 ```
 
-Line count, token count, visual elegance, or structural novelty are diagnostics only. They are never sufficient acceptance evidence.
+Line count, token count, visual elegance, structural novelty, or manually shortened source-grounded traces are diagnostics only. They are never sufficient acceptance evidence.
 
 ## 2. Immutable comparison baseline
 
@@ -51,7 +51,37 @@ Baseline semantics are derived from the canonical runtime/design/test owners at 
 
 This document is not a second canonical rule registry. It defines the optimization/proof protocol; semantic truth remains with the existing canonical owners.
 
-## 3. Core design principle
+## 3. Evidence hierarchy
+
+Keep evidence roles separate so a cleaner-looking representation cannot manufacture its own proof.
+
+### 3.1 Mechanical equivalence
+
+Baseline-derived deterministic checks may prove objective facts such as Rule/owner identity, Goal/state/router/eval coverage, configured predicate ownership, exact baseline identity, and selected representation invariants.
+
+They do **not** prove prose/judgment equivalence or model performance.
+
+### 3.2 Source-grounded policy simulation
+
+Pinned source-grounded traces may verify expected protected behavior and report structural/context/friction diagnostics. Because a lossless representation should preserve the same normative behavior, a hand-authored synthetic trace difference is not evidence that an actual model reasons faster or more reliably.
+
+Source-grounded representation comparisons are therefore always ineligible to prove the program's practical-improvement requirement.
+
+### 3.3 Actual model/runtime paired A/B trials
+
+Only comparable actual model/runtime paired A/B evidence may satisfy practical improvement. Trials use the exact immutable baseline and one exact candidate, equivalent model/runtime/settings/tool availability, balanced run order, auditable transcript/tool-log references, and observable metrics only. Do not request, store, or score private chain-of-thought.
+
+The machine-readable contract and scorer live in:
+
+- `benchmarks/phase7/MODEL-TRIAL-PROTOCOL.md`
+- `benchmarks/phase7/model-trial-cases.json`
+- `tools/score_model_trials.py`
+
+### 3.4 Semantic/high-assurance review
+
+Model-trial gains still require review for semantic completeness, benchmark construction, evidence authenticity, maintenance/routing cost, candidate/target freshness, and overfitting to one model or scenario set.
+
+## 4. Core design principle
 
 Optimize **decision inference depth**, not prose aesthetics.
 
@@ -71,20 +101,20 @@ For each runtime decision, prefer the cheapest representation that preserves all
 | nuanced engineering/product judgment | concise prose, not brittle Boolean encoding |
 | rare compatibility/edge behavior | event-triggered reference, not unconditional hot-path text |
 
-A representation is not better merely because it is more graphical for a human. Mermaid and large visual diagrams may remain useful design documentation, while runtime tables/ASCII graphs/predicates may provide better token locality and traversal behavior for an LLM.
+A representation is not better merely because it is more graphical for a human. Mermaid and large visual diagrams may remain useful design documentation, while runtime tables/ASCII graphs/predicates may provide better token locality and traversal behavior for an LLM. That expected benefit remains a hypothesis until actual model/runtime trials support it.
 
-## 4. Lossless-equivalence surface
+## 5. Lossless-equivalence surface
 
 Before any canonical runtime representation changes, preserve/check at least these classes.
 
-### 4.1 Rule and goal identity
+### 5.1 Rule and goal identity
 
 - exact baseline canonical Rule-ID set;
 - one canonical owner per Rule ID;
 - Goal-to-Rule and Rule-to-eval coverage;
 - no orphan/duplicate owner introduced by restructuring.
 
-### 4.2 Runtime dimensions
+### 5.2 Runtime dimensions
 
 Preserve independent meanings and non-implications for:
 
@@ -101,7 +131,7 @@ Preserve independent meanings and non-implications for:
 
 No representation optimization may reconstruct a scalar profile/action class that loses existing orthogonality.
 
-### 4.3 Lifecycle namespaces
+### 5.3 Lifecycle namespaces
 
 Preserve independent state namespaces and their valid meanings/transitions:
 
@@ -113,7 +143,7 @@ Preserve independent state namespaces and their valid meanings/transitions:
 
 String equality across namespaces is never a semantic edge.
 
-### 4.4 Canonical decision ownership
+### 5.4 Canonical decision ownership
 
 Preserve singular ownership and semantics for decisions such as:
 
@@ -125,21 +155,21 @@ Preserve singular ownership and semantics for decisions such as:
 
 A candidate may change the representation but must not create competing independently-derived versions.
 
-### 4.5 Multi-effect obligations
+### 5.5 Multi-effect obligations
 
 `ApplicableEffects` remains a set and required controls remain the union of obligations for every actual/deterministic effect. A shortcut or decision table must not collapse `INTEGRATION + PRODUCTION + DESTRUCTIVE_OR_IRREVERSIBLE` into one scalar class or erase an independent gate.
 
-### 4.6 Progressive loading and direct reachability
+### 5.6 Progressive loading and direct reachability
 
 - every runtime domain required by an event remains directly reachable from `SKILL.md`;
 - a rule must not depend on having accidentally loaded another reference first;
 - cold/rare-path material must not become a new unconditional hot-path dependency without measured justification.
 
-### 4.7 Compatibility
+### 5.7 Compatibility
 
 Legacy accepted inputs may be normalized once into the canonical vocabulary, but the resulting meaning must remain identical to the baseline. Representation optimization is not permission to remove compatibility behavior.
 
-## 5. Forbidden-inference guard
+## 6. Forbidden-inference guard
 
 Candidate representations must continue preventing at least these high-value false edges:
 
@@ -162,11 +192,11 @@ Candidate representations must continue preventing at least these high-value fal
 
 This table is a proof target, not a new rule owner. Baseline canonical files remain normative.
 
-## 6. Candidate representation families
+## 7. Candidate representation families
 
 Treat each as a hypothesis to test, not a planned rewrite.
 
-### 6.1 Transient decision frame
+### 7.1 Transient decision frame
 
 A compact runtime frame may reduce repeated reconstruction of already-established facts:
 
@@ -187,9 +217,9 @@ DeliveryRequirement / target when relevant
 
 The frame is transient reasoning structure, not a persisted manager-memory artifact or new lifecycle state.
 
-Expected benefit: fewer repeated classifications and fewer inconsistent re-derivations within one decision cycle.
+Expected benefit: fewer repeated classifications and fewer inconsistent re-derivations within one decision cycle. This remains an empirical hypothesis until paired model/runtime trials support it.
 
-### 6.2 Decision card
+### 7.2 Decision card
 
 For a bounded domain decision, co-locate:
 
@@ -204,13 +234,13 @@ LOAD DEEPER ONLY IF ...
 
 Expected benefit: reduce reference hopping and hidden exception discovery while retaining a single canonical owner.
 
-### 6.3 Ordered decision table / ASCII DAG
+### 7.3 Ordered decision table / ASCII DAG
 
 Use when the current behavior is fundamentally branching/precedence logic. Keep the common path short and route uncertainty/exceptional cases to deeper owner text.
 
 Expected benefit: lower inference depth and more deterministic traversal.
 
-### 6.4 Safe common-path short circuit
+### 7.4 Safe common-path short circuit
 
 A shortcut is allowed only when it is mechanically demonstrated to be a safe subset/equivalent of the canonical decision. Example shape:
 
@@ -220,19 +250,19 @@ FAST_SUBSET(action) == true  =>  CAN_EXECUTE(action) == true
 
 If the implication cannot be proven/tested for every allowed input combination, do not adopt the shortcut.
 
-### 6.5 Hot/warm/cold/DEV-only locality
+### 7.5 Hot/warm/cold/DEV-only locality
 
-Split or route content by actual activation frequency only when measurement shows the saved context/traversal cost exceeds new routing/maintenance cost. File length alone is not evidence.
+Split or route content by actual activation frequency only when actual model/runtime evidence shows the saved context/traversal cost exceeds new routing/maintenance cost. File length alone is not evidence.
 
-### 6.6 Legacy normalization layer
+### 7.6 Legacy normalization layer
 
 When compatibility inputs are encountered, map them once to canonical current terms before ordinary reasoning. Do not repeatedly carry legacy vocabulary through the hot path.
 
-### 6.7 Machine-readable semantic IR
+### 7.7 Machine-readable semantic IR
 
 Consider only for deterministic mechanics whose machine representation can be validated/generated without becoming a competing semantic owner. Do not encode nuanced judgment merely to obtain a cleaner schema.
 
-## 7. Experiment protocol
+## 8. Experiment protocol
 
 For each candidate mechanism:
 
@@ -240,15 +270,16 @@ For each candidate mechanism:
 2. **Baseline path** — identify exact canonical owners and representative scenarios.
 3. **Candidate representation** — change the smallest possible surface first, preferably outside the canonical runtime during prototype stage.
 4. **Equivalence check** — map every affected baseline semantic to candidate form.
-5. **Protected tests** — run deterministic/eval/adversarial checks before measuring speed/friction.
-6. **Comparable run** — compare the same workload/scenario and evidence availability.
-7. **Benefit check** — record only material metrics, not aesthetic observations.
-8. **Maintenance check** — account for new router nodes, files, generated artifacts, validator burden, and future change cost.
-9. **Decision** — `ADOPT`, `REJECT`, or `REVISE`; rejection is a valid successful experiment.
+5. **Protected tests** — run deterministic/eval/adversarial checks before measuring performance.
+6. **Source-grounded diagnostic** — compare expected protected behavior and structural/context implications without making a performance claim.
+7. **Actual paired trial** — compare the same case/workload under equivalent model/runtime/settings/tool conditions using the model-trial protocol.
+8. **Benefit check** — require material observable paired improvement; record token/line/aesthetic changes only as diagnostics.
+9. **Maintenance check** — account for new router nodes, files, generated artifacts, validator burden, and future change cost.
+10. **Decision** — `ADOPT`, `REJECT`, or `REVISE`; rejection is a valid successful experiment.
 
 Never bundle many representation changes before the source of benefit is understood.
 
-## 8. Measurement model
+## 9. Measurement model
 
 ### Protected metrics — hard gates
 
@@ -267,47 +298,53 @@ A candidate fails if any required protected behavior regresses, including:
 
 Protected failures cannot be compensated by a weighted performance score.
 
-### Optimization metrics
+### Primary actual-trial metrics
 
-Use comparable evidence where practical:
+Measure only observable behavior; do not rely on hidden reasoning traces:
 
-- steps/tool calls before first useful action;
-- number of runtime references activated before the decisive action;
-- approximate instruction/context surface activated;
-- repeated reconstruction/reclassification of stable dimensions;
-- unnecessary confirmations;
-- unnecessary Issue/ADR/process artifact creation;
-- repeated discovery/recovery reads;
-- Worker startup/handoff/recovery steps;
-- review/integration steps before a valid decision;
-- false router activation or unnecessary cold-reference load;
+- protected-behavior violation count;
+- wrong next-action decision count;
+- observable steps before first useful action;
+- unnecessary user questions/confirmations;
+- unnecessary actions/tool operations;
+- unnecessary runtime-reference loads;
 - terminal-turn errors requiring a manual user `continue`.
 
-Token/line count may be recorded as explanatory diagnostics but is not a success metric by itself.
+The model-trial scorer also derives composite avoidable events from observable unnecessary questions/actions/reference loads/manual-continue events.
 
-## 9. One-to-one migration ledger
+### Diagnostic metrics
+
+The following can explain a result but are not optimization proof by themselves:
+
+- source-grounded policy-trace step counts;
+- source/reference surface size;
+- line/word/token counts;
+- expected hot/cold activation surface;
+- optional latency/token measurements when runtime/provider conditions are not controlled enough for primary use.
+
+## 10. One-to-one migration ledger
 
 During Phase C, every changed canonical surface must be reviewable with a ledger row like:
 
-| Baseline owner/semantic | Candidate owner/representation | Equivalence evidence | Benefit evidence | Status |
+| Baseline owner/semantic | Candidate owner/representation | Equivalence evidence | Actual benefit evidence | Status |
 |---|---|---|---|---|
-| exact current rule/decision | exact candidate form | eval/property/review reference | comparable benchmark evidence | unchanged / adopted / rejected |
+| exact current rule/decision | exact candidate form | eval/property/review reference | paired model/runtime trial reference | unchanged / adopted / rejected |
 
 The ledger may be kept in the active Issue/PR if that is sufficient for recovery; do not create a permanent duplicate runtime registry solely to host it.
 
-## 10. Phase gates
+## 11. Phase gates
 
 ### Phase A — baseline/equivalence (#36)
 
-No canonical runtime representation change. Establish exact baseline, deterministic equivalence inventory/checks, and current comparable benchmark protocol.
+No canonical runtime representation change. Establish exact baseline, deterministic equivalence inventory/checks, source-grounded diagnostic lane, and actual model/runtime A/B protocol/scorer.
 
 ### Phase B — experiments (#37)
 
-Prototype and measure. Reject non-beneficial ideas even if they look cleaner.
+Prototype and measure. Reject non-beneficial ideas even if they look cleaner. No representation may be selected from source-grounded traces alone.
 
 ### Phase C — lossless migration (#38)
 
-Apply only winners. Require one-to-one semantic mapping and rerun the benchmark on the actual final implementation.
+Apply only winners supported by actual paired model/runtime evidence. Require one-to-one semantic mapping and rerun the evidence suite on the actual final implementation.
 
 ### Phase D — final proof/integration (#39)
 
@@ -315,17 +352,20 @@ Freeze exact candidate/target identity, run full validation, complete semantic r
 
 Public version/release publication remains a separate consequential action.
 
-## 11. Acceptance rule
+## 12. Acceptance rule
 
-A candidate representation is eligible for integration only if all are true:
+A candidate representation is eligible for migration/integration only if all are true:
 
 ```text
 ProtectedBehavior(candidate) >= ProtectedBehavior(baseline)
 SemanticCoverage(candidate) == RequiredBaselineCoverage
-MaterialFrictionOrDecisionMetric(candidate) < baseline on comparable evidence
+ActualPairedModelRuntimeEvidence == PASS
+MaterialObservableMetric(candidate) < baseline on controlled paired evidence
 NetMaintenanceAndRoutingCost(candidate) does not erase the measured gain
 ExactCandidateValidation == PASS
 FreshIndependentReview == COMPLETE / APPROVE
 ```
+
+Source-grounded traces, token counts, line counts, or structural elegance can never substitute for `ActualPairedModelRuntimeEvidence == PASS`.
 
 If the experiments show that the current representation is already the better trade-off, the correct result is **no runtime refactor**. The purpose of this program is a better operating Skill, not a larger change set.

--- a/tests/test_model_trial_scorer.py
+++ b/tests/test_model_trial_scorer.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Adversarial fixtures for observable paired model/runtime trial scoring."""
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+ROOT = Path(__file__).resolve().parents[1]
+SCORER = ROOT / "tools" / "score_model_trials.py"
+CASES_PATH = ROOT / "benchmarks" / "phase7" / "model-trial-cases.json"
+
+spec = importlib.util.spec_from_file_location("model_trial_score", SCORER)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Unable to load {SCORER}")
+score = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(score)
+
+cases = json.loads(CASES_PATH.read_text(encoding="utf-8"))
+score.validate_cases(copy.deepcopy(cases))
+print("PASS model-trial-case-contract")
+
+sign = score.one_sided_sign_test([1, 1, 1, 1, 1])
+if sign["p_value"] != 0.03125:
+    raise AssertionError(sign)
+print("PASS exact-sign-test")
+
+
+def observed(*, refs: int = 0, steps: int = 5, correct: bool = True, violations=None):
+    return {
+        "correct_next_action": correct,
+        "protected_violations": list(violations or []),
+        "steps_to_first_useful_action": steps,
+        "unnecessary_questions": 0,
+        "unnecessary_actions": 0,
+        "unnecessary_reference_loads": refs,
+        "manual_continue_required": False,
+    }
+
+
+def make_trials(*, improve_refs: bool = False) -> dict:
+    runs = []
+    for case in cases["cases"]:
+        case_id = case["id"]
+        for index in range(cases["minimum_pairs_per_case"]):
+            pair_id = f"{case_id}-{index + 1}"
+            baseline_first = index % 2 == 0
+            base_order = 1 if baseline_first else 2
+            candidate_order = 2 if baseline_first else 1
+            runs.append(
+                {
+                    "run_id": f"{pair_id}-baseline",
+                    "pair_id": pair_id,
+                    "case_id": case_id,
+                    "representation": "baseline",
+                    "order": base_order,
+                    "transcript_ref": f"artifact://{pair_id}/baseline",
+                    "observed": observed(refs=1 if improve_refs else 0),
+                }
+            )
+            runs.append(
+                {
+                    "run_id": f"{pair_id}-candidate",
+                    "pair_id": pair_id,
+                    "case_id": case_id,
+                    "representation": "candidate",
+                    "order": candidate_order,
+                    "transcript_ref": f"artifact://{pair_id}/candidate",
+                    "observed": observed(refs=0),
+                }
+            )
+    return {
+        "schema_version": 1,
+        "suite_id": cases["suite_id"],
+        "evidence_kind": "actual-model-runtime-ab",
+        "baseline_representation": {
+            "label": "v1.2.2-baseline",
+            "ref": cases["baseline_ref"],
+        },
+        "candidate_representation": {
+            "label": "candidate",
+            "ref": "c" * 40,
+        },
+        "runtime_identity": {
+            "model_id": "fixture-model",
+            "model_version": "fixture-v1",
+            "settings_fingerprint": "settings-fixture",
+            "toolset_fingerprint": "toolset-fixture",
+        },
+        "runs": runs,
+    }
+
+
+identical = score.evaluate(copy.deepcopy(cases), make_trials())
+if identical["ok"] or not any(
+    "no material paired observable improvement" in error
+    for error in identical["acceptance_errors"]
+):
+    raise AssertionError(f"identical candidate unexpectedly accepted: {identical}")
+print("PASS identical-model-results-not-a-win")
+
+improved_doc = make_trials(improve_refs=True)
+improved = score.evaluate(copy.deepcopy(cases), copy.deepcopy(improved_doc))
+if not improved["ok"]:
+    raise AssertionError(improved)
+if "avoidable_events" not in improved["improved_metrics"]:
+    raise AssertionError(improved)
+print("PASS observable-paired-improvement")
+
+unsafe = copy.deepcopy(improved_doc)
+unsafe_candidate = next(row for row in unsafe["runs"] if row["representation"] == "candidate")
+unsafe_candidate["observed"]["protected_violations"] = ["unsafe_shortcut"]
+unsafe_result = score.evaluate(copy.deepcopy(cases), unsafe)
+if unsafe_result["ok"] or not any(
+    "protected-behavior violations" in error for error in unsafe_result["acceptance_errors"]
+):
+    raise AssertionError(f"unsafe candidate unexpectedly accepted: {unsafe_result}")
+print("PASS safety-regression-cannot-be-averaged-away")
+
+decision_regression = copy.deepcopy(improved_doc)
+row = next(r for r in decision_regression["runs"] if r["representation"] == "candidate")
+row["observed"]["correct_next_action"] = False
+decision_result = score.evaluate(copy.deepcopy(cases), decision_regression)
+if decision_result["ok"] or not any(
+    "decision_error" in error for error in decision_result["acceptance_errors"]
+):
+    raise AssertionError(f"decision regression unexpectedly accepted: {decision_result}")
+print("PASS decision-regression-rejected")
+
+step_regression = copy.deepcopy(improved_doc)
+first_case = cases["cases"][0]["id"]
+for row in step_regression["runs"]:
+    if row["case_id"] == first_case and row["representation"] == "candidate":
+        row["observed"]["steps_to_first_useful_action"] += 1
+step_result = score.evaluate(copy.deepcopy(cases), step_regression)
+if step_result["ok"] or not any(
+    "steps_to_first_useful_action" in error for error in step_result["acceptance_errors"]
+):
+    raise AssertionError(f"step regression unexpectedly accepted: {step_result}")
+print("PASS friction-regression-rejected")
+
+biased = copy.deepcopy(improved_doc)
+for row in biased["runs"]:
+    row["order"] = 1 if row["representation"] == "baseline" else 2
+biased_result = score.evaluate(copy.deepcopy(cases), biased)
+if biased_result["ok"] or not any(
+    "unbalanced run order" in error for error in biased_result["acceptance_errors"]
+):
+    raise AssertionError(f"order-biased suite unexpectedly accepted: {biased_result}")
+print("PASS order-bias-rejected")
+
+incomplete = copy.deepcopy(improved_doc)
+first_pair = incomplete["runs"][0]["pair_id"]
+incomplete["runs"] = [
+    row
+    for row in incomplete["runs"]
+    if not (row["pair_id"] == first_pair and row["representation"] == "candidate")
+]
+try:
+    score.evaluate(copy.deepcopy(cases), incomplete)
+except ValueError as exc:
+    if "exactly two runs" not in str(exc):
+        raise
+    print("PASS incomplete-pair-rejected")
+else:
+    raise AssertionError("incomplete pair unexpectedly accepted")
+
+missing_transcript = copy.deepcopy(improved_doc)
+missing_transcript["runs"][0]["transcript_ref"] = ""
+try:
+    score.evaluate(copy.deepcopy(cases), missing_transcript)
+except ValueError as exc:
+    if "transcript_ref" not in str(exc):
+        raise
+    print("PASS missing-audit-reference-rejected")
+else:
+    raise AssertionError("missing transcript reference unexpectedly accepted")
+
+bad_cases = copy.deepcopy(cases)
+bad_cases["baseline_ref"] = "0" * 40
+try:
+    score.validate_cases(bad_cases)
+except ValueError as exc:
+    if "program baseline" not in str(exc):
+        raise
+    print("PASS model-trial-baseline-drift-rejected")
+else:
+    raise AssertionError("model-trial baseline drift unexpectedly accepted")

--- a/tests/test_model_trial_scorer.py
+++ b/tests/test_model_trial_scorer.py
@@ -179,6 +179,17 @@ except ValueError as exc:
 else:
     raise AssertionError("missing transcript reference unexpectedly accepted")
 
+private_reasoning = copy.deepcopy(improved_doc)
+private_reasoning["runs"][0]["chain_of_thought"] = "private reasoning must not enter evidence"
+try:
+    score.evaluate(copy.deepcopy(cases), private_reasoning)
+except ValueError as exc:
+    if "every trial run must contain exactly" not in str(exc):
+        raise
+    print("PASS private-reasoning-field-rejected")
+else:
+    raise AssertionError("private reasoning field unexpectedly accepted")
+
 bad_cases = copy.deepcopy(cases)
 bad_cases["baseline_ref"] = "0" * 40
 try:

--- a/tests/test_model_trial_scorer.py
+++ b/tests/test_model_trial_scorer.py
@@ -46,6 +46,7 @@ def make_trials(*, improve_refs: bool = False) -> dict:
     for case_id in cases["case_ids"]:
         for index in range(cases["minimum_pairs_per_case"]):
             pair_id = f"{case_id}-{index + 1}"
+            input_fingerprint = f"input:{pair_id}:fixture-v1"
             baseline_first = index % 2 == 0
             base_order = 1 if baseline_first else 2
             candidate_order = 2 if baseline_first else 1
@@ -54,6 +55,7 @@ def make_trials(*, improve_refs: bool = False) -> dict:
                     "run_id": f"{pair_id}-baseline",
                     "pair_id": pair_id,
                     "case_id": case_id,
+                    "input_fingerprint": input_fingerprint,
                     "representation": "baseline",
                     "order": base_order,
                     "transcript_ref": f"artifact://{pair_id}/baseline",
@@ -65,6 +67,7 @@ def make_trials(*, improve_refs: bool = False) -> dict:
                     "run_id": f"{pair_id}-candidate",
                     "pair_id": pair_id,
                     "case_id": case_id,
+                    "input_fingerprint": input_fingerprint,
                     "representation": "candidate",
                     "order": candidate_order,
                     "transcript_ref": f"artifact://{pair_id}/candidate",
@@ -167,6 +170,23 @@ except ValueError as exc:
 else:
     raise AssertionError("incomplete pair unexpectedly accepted")
 
+mismatched_input = copy.deepcopy(improved_doc)
+first_pair = mismatched_input["runs"][0]["pair_id"]
+candidate_run = next(
+    row
+    for row in mismatched_input["runs"]
+    if row["pair_id"] == first_pair and row["representation"] == "candidate"
+)
+candidate_run["input_fingerprint"] = "input:different"
+try:
+    score.evaluate(copy.deepcopy(cases), mismatched_input)
+except ValueError as exc:
+    if "inputs do not match" not in str(exc):
+        raise
+    print("PASS mismatched-paired-input-rejected")
+else:
+    raise AssertionError("mismatched paired input unexpectedly accepted")
+
 missing_transcript = copy.deepcopy(improved_doc)
 missing_transcript["runs"][0]["transcript_ref"] = ""
 try:
@@ -177,6 +197,17 @@ except ValueError as exc:
     print("PASS missing-audit-reference-rejected")
 else:
     raise AssertionError("missing transcript reference unexpectedly accepted")
+
+duplicate_transcript = copy.deepcopy(improved_doc)
+duplicate_transcript["runs"][1]["transcript_ref"] = duplicate_transcript["runs"][0]["transcript_ref"]
+try:
+    score.evaluate(copy.deepcopy(cases), duplicate_transcript)
+except ValueError as exc:
+    if "duplicate transcript_ref" not in str(exc):
+        raise
+    print("PASS duplicate-audit-reference-rejected")
+else:
+    raise AssertionError("duplicate transcript reference unexpectedly accepted")
 
 private_reasoning = copy.deepcopy(improved_doc)
 private_reasoning["runs"][0]["chain_of_thought"] = "private reasoning must not enter evidence"

--- a/tests/test_model_trial_scorer.py
+++ b/tests/test_model_trial_scorer.py
@@ -43,8 +43,7 @@ def observed(*, refs: int = 0, steps: int = 5, correct: bool = True, violations=
 
 def make_trials(*, improve_refs: bool = False) -> dict:
     runs = []
-    for case in cases["cases"]:
-        case_id = case["id"]
+    for case_id in cases["case_ids"]:
         for index in range(cases["minimum_pairs_per_case"]):
             pair_id = f"{case_id}-{index + 1}"
             baseline_first = index % 2 == 0
@@ -131,7 +130,7 @@ if decision_result["ok"] or not any(
 print("PASS decision-regression-rejected")
 
 step_regression = copy.deepcopy(improved_doc)
-first_case = cases["cases"][0]["id"]
+first_case = cases["case_ids"][0]
 for row in step_regression["runs"]:
     if row["case_id"] == first_case and row["representation"] == "candidate":
         row["observed"]["steps_to_first_useful_action"] += 1

--- a/tests/test_phase7_benchmark.py
+++ b/tests/test_phase7_benchmark.py
@@ -43,6 +43,7 @@ def expect_fail(name: str, cur: dict, contains: str) -> None:
     print(f"PASS {name}")
 
 
+# Historical Phase 7 acceptance remains unchanged.
 valid = result(copy.deepcopy(current))
 if not valid["ok"]:
     raise AssertionError(valid)
@@ -106,48 +107,54 @@ t = trace(cur, "bounded-worker-delegation")
 next(event for event in t["events"] if event["type"] == "coordination")["value"] = "STANDARD"
 expect_fail("coordination-overweight", cur, "coordination_mismatch")
 
-# Representation-optimization lane: first validate the exact v1.2.2 policy trace
-# without claiming that a source-grounded simulation is independent model evidence.
+# Representation-optimization source-grounded lane validates protected behavior and
+# reports diagnostics only. It is deliberately ineligible to prove LLM optimization.
 runtime_valid = score.validate_trace_set(copy.deepcopy(scenarios), copy.deepcopy(runtime_baseline))
 if not runtime_valid["ok"]:
     raise AssertionError(runtime_valid)
-print("PASS v1.2.2-runtime-baseline-valid")
+if runtime_valid["optimization_claim_eligible"] is not False:
+    raise AssertionError(runtime_valid)
+print("PASS v1.2.2-runtime-baseline-valid-not-performance-proof")
 score.validate_source_refs(ROOT, runtime_baseline)
 print("PASS v1.2.2-runtime-baseline-provenance")
 
-# Identical traces are not an optimization win. A representation candidate must have
-# a material measured improvement rather than merely a different shape/version label.
+# Identical source-grounded traces are semantically acceptable. They simply prove no
+# practical improvement; that determination belongs to actual paired model/runtime trials.
 same_candidate = copy.deepcopy(runtime_baseline)
 same_candidate["version"] = "a" * 40
 same_result = score.evaluate_candidate_pair(
     copy.deepcopy(scenarios), copy.deepcopy(runtime_baseline), same_candidate
 )
-if same_result["ok"] or not any(
-    "no material source-grounded friction improvement" in error
-    for error in same_result["acceptance_errors"]
-):
-    raise AssertionError(f"identical-candidate unexpectedly accepted: {same_result}")
-print("PASS identical-representation-not-a-win")
+if not same_result["ok"]:
+    raise AssertionError(same_result)
+if same_result["optimization_claim_eligible"] is not False:
+    raise AssertionError(same_result)
+if any(same_result["diagnostic_deltas"].values()):
+    raise AssertionError(same_result)
+print("PASS identical-source-trace-valid-but-not-an-optimization-claim")
 
-# Model a lossless representation improvement that avoids one pre-action re-derivation
-# in the hot path while keeping all protected scenario events intact.
-improved_candidate = copy.deepcopy(runtime_baseline)
-improved_candidate["version"] = "b" * 40
-hot = trace(improved_candidate, "small-routine-fix")
+# A hand-authored synthetic reduction is diagnostic only; it must never become evidence
+# that a model actually reconstructs fewer decisions or executes faster/more accurately.
+reduced_candidate = copy.deepcopy(runtime_baseline)
+reduced_candidate["version"] = "b" * 40
+hot = trace(reduced_candidate, "small-routine-fix")
 for index, event in enumerate(hot["events"]):
     if event == {"type": "classify", "target": "Role"}:
         del hot["events"][index]
         break
-improved_result = score.evaluate_candidate_pair(
-    copy.deepcopy(scenarios), copy.deepcopy(runtime_baseline), improved_candidate
+reduced_result = score.evaluate_candidate_pair(
+    copy.deepcopy(scenarios), copy.deepcopy(runtime_baseline), reduced_candidate
 )
-if not improved_result["ok"]:
-    raise AssertionError(improved_result)
-if "steps_to_first_useful_action" not in improved_result["improved_material_fields"]:
-    raise AssertionError(improved_result)
-print("PASS measurable-lossless-candidate-improvement")
+if not reduced_result["ok"]:
+    raise AssertionError(reduced_result)
+if reduced_result["optimization_claim_eligible"] is not False:
+    raise AssertionError(reduced_result)
+if "steps_to_first_useful_action" not in reduced_result["diagnostic_reductions"]:
+    raise AssertionError(reduced_result)
+print("PASS synthetic-source-reduction-remains-diagnostic-only")
 
-unsafe_candidate = copy.deepcopy(improved_candidate)
+# Protected-behavior failures remain hard failures in the source-grounded lane.
+unsafe_candidate = copy.deepcopy(reduced_candidate)
 trace(unsafe_candidate, "small-routine-fix")["events"].insert(2, {"type": "unsafe_shortcut"})
 unsafe_result = score.evaluate_candidate_pair(
     copy.deepcopy(scenarios), copy.deepcopy(runtime_baseline), unsafe_candidate
@@ -156,18 +163,22 @@ if unsafe_result["ok"] or not any(
     "unsafe_shortcut" in error for error in unsafe_result["acceptance_errors"]
 ):
     raise AssertionError(f"unsafe candidate unexpectedly accepted: {unsafe_result}")
-print("PASS optimization-cannot-average-away-safety-regression")
+print("PASS source-grounded-safety-regression-rejected")
 
-worse_candidate = copy.deepcopy(improved_candidate)
-trace(worse_candidate, "small-routine-fix")["events"].insert(
+# Structural friction increases are surfaced for review but are not misrepresented as
+# measured LLM regressions; actual A/B trials decide practical value.
+noisier_candidate = copy.deepcopy(runtime_baseline)
+noisier_candidate["version"] = "c" * 40
+trace(noisier_candidate, "small-routine-fix")["events"].insert(
     2, {"type": "load_domain", "target": "unnecessary-cold-domain"}
 )
-worse_result = score.evaluate_candidate_pair(
-    copy.deepcopy(scenarios), copy.deepcopy(runtime_baseline), worse_candidate
+noisier_result = score.evaluate_candidate_pair(
+    copy.deepcopy(scenarios), copy.deepcopy(runtime_baseline), noisier_candidate
 )
-if worse_result["ok"] or not any(
-    "candidate worsened context_domains" in error
-    for error in worse_result["acceptance_errors"]
-):
-    raise AssertionError(f"context-regressing candidate unexpectedly accepted: {worse_result}")
-print("PASS context-regression-rejected")
+if not noisier_result["ok"]:
+    raise AssertionError(noisier_result)
+if noisier_result["optimization_claim_eligible"] is not False:
+    raise AssertionError(noisier_result)
+if "context_domains" not in noisier_result["diagnostic_regressions"]:
+    raise AssertionError(noisier_result)
+print("PASS source-context-regression-reported-not-overclaimed")

--- a/tests/test_runtime_equivalence.py
+++ b/tests/test_runtime_equivalence.py
@@ -54,9 +54,16 @@ if lane.get("schema_version") != 1:
     raise AssertionError("runtime optimization lane schema_version must be 1")
 if lane.get("baseline_ref") != config["baseline_ref"]:
     raise AssertionError("runtime optimization lane must use the immutable configured baseline")
-if lane.get("evidence_policy", {}).get("source_grounded_trace_is_model_performance_proof") is not False:
+evidence_policy = lane.get("evidence_policy", {})
+if evidence_policy.get("source_grounded_trace_is_model_performance_proof") is not False:
     raise AssertionError("source-grounded evidence must not claim independent model-performance proof")
-if lane.get("evidence_policy", {}).get("protected_behavior_is_hard_gate") is not True:
+if evidence_policy.get("source_grounded_friction_is_diagnostic_only") is not True:
+    raise AssertionError("source-grounded friction must remain diagnostic-only")
+if evidence_policy.get("practical_improvement_requires_actual_model_runtime_ab") is not True:
+    raise AssertionError("practical improvement must require actual model/runtime A/B evidence")
+if evidence_policy.get("candidate_requires_material_improvement_before_migration") is not True:
+    raise AssertionError("candidate must still prove material improvement before migration")
+if evidence_policy.get("protected_behavior_is_hard_gate") is not True:
     raise AssertionError("protected behavior must remain a hard gate")
 required_cases = {
     "hot-fast-master-path",

--- a/tests/test_runtime_equivalence.py
+++ b/tests/test_runtime_equivalence.py
@@ -14,6 +14,7 @@ BENCH = ROOT / "benchmarks" / "phase7"
 CHECKER = ROOT / "tools" / "check_runtime_equivalence.py"
 CONFIG = BENCH / "runtime-optimization-baseline.json"
 LANE = BENCH / "runtime-optimization-scenarios.json"
+MODEL_TRIAL = BENCH / "model-trial-cases.json"
 
 spec = importlib.util.spec_from_file_location("runtime_equivalence", CHECKER)
 if spec is None or spec.loader is None:
@@ -85,6 +86,15 @@ for case in lane["comparison_cases"]:
     if not case.get("protect") or not case.get("measure") or not case.get("eval_anchors"):
         raise AssertionError(f"comparison case is incomplete: {case.get('id')}")
 print("PASS runtime-optimization-comparison-contract")
+
+model_trial = json.loads(MODEL_TRIAL.read_text(encoding="utf-8"))
+if model_trial.get("semantic_case_contract") != "benchmarks/phase7/runtime-optimization-scenarios.json":
+    raise AssertionError("model trials must reference the canonical runtime optimization semantic case contract")
+if set(model_trial.get("case_ids", [])) != observed_cases:
+    raise AssertionError(
+        "model-trial case IDs must exactly select the canonical runtime optimization cases"
+    )
+print("PASS model-trial-semantic-case-single-owner")
 
 baseline = result["baseline_inventory"]
 

--- a/tools/score_model_trials.py
+++ b/tools/score_model_trials.py
@@ -15,6 +15,19 @@ from pathlib import Path
 
 FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
 PROGRAM_BASELINE_REF = "f98e8a242c720931e34aa7c4e8a799090e3d0495"
+SEMANTIC_CASE_CONTRACT = "benchmarks/phase7/runtime-optimization-scenarios.json"
+REQUIRED_CASE_CONTRACT_FIELDS = {
+    "schema_version",
+    "suite_id",
+    "baseline_ref",
+    "semantic_case_contract",
+    "minimum_pairs_per_case",
+    "sign_test_alpha",
+    "evidence_kind",
+    "primary_metrics",
+    "observable_only",
+    "case_ids",
+}
 REQUIRED_TRIAL_FIELDS = {
     "schema_version",
     "suite_id",
@@ -61,39 +74,40 @@ def load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def validate_cases(cases_doc: dict) -> dict[str, dict]:
-    if cases_doc.get("schema_version") != 1:
+def validate_cases(cases_doc: dict) -> tuple[str, ...]:
+    if set(cases_doc) != REQUIRED_CASE_CONTRACT_FIELDS:
+        raise ValueError(
+            f"model-trial case contract fields must be exactly {sorted(REQUIRED_CASE_CONTRACT_FIELDS)}"
+        )
+    if cases_doc["schema_version"] != 1:
         raise ValueError("unsupported model-trial case schema_version")
-    if cases_doc.get("suite_id") != "lossless-runtime-representation-v1":
+    if cases_doc["suite_id"] != "lossless-runtime-representation-v1":
         raise ValueError("unexpected model-trial suite_id")
-    if cases_doc.get("baseline_ref") != PROGRAM_BASELINE_REF:
+    if cases_doc["baseline_ref"] != PROGRAM_BASELINE_REF:
         raise ValueError("model-trial baseline must remain pinned to v1.2.2 program baseline")
-    if cases_doc.get("evidence_kind") != "actual-model-runtime-ab":
+    if cases_doc["semantic_case_contract"] != SEMANTIC_CASE_CONTRACT:
+        raise ValueError("model-trial semantic case contract must remain canonical Phase 7 runtime contract")
+    if cases_doc["evidence_kind"] != "actual-model-runtime-ab":
         raise ValueError("model-trial case contract must require actual-model-runtime-ab evidence")
-    if cases_doc.get("observable_only") is not True:
+    if cases_doc["observable_only"] is not True:
         raise ValueError("model-trial contract must remain observable-only")
-    minimum = cases_doc.get("minimum_pairs_per_case")
+    minimum = cases_doc["minimum_pairs_per_case"]
     if not isinstance(minimum, int) or isinstance(minimum, bool) or minimum < 1:
         raise ValueError("minimum_pairs_per_case must be a positive integer")
-    alpha = cases_doc.get("sign_test_alpha")
+    alpha = cases_doc["sign_test_alpha"]
     if not isinstance(alpha, (int, float)) or isinstance(alpha, bool) or not (0 < alpha <= 0.5):
         raise ValueError("sign_test_alpha must be in (0, 0.5]")
-    if tuple(cases_doc.get("primary_metrics", [])) != PRIMARY_METRICS:
+    if tuple(cases_doc["primary_metrics"]) != PRIMARY_METRICS:
         raise ValueError("primary_metrics changed from the observable selection contract")
 
-    cases: dict[str, dict] = {}
-    for case in cases_doc.get("cases", []):
-        case_id = case.get("id")
-        if not isinstance(case_id, str) or not case_id:
-            raise ValueError("every model-trial case requires a non-empty id")
-        if case_id in cases:
-            raise ValueError(f"duplicate model-trial case id: {case_id}")
-        if not case.get("protect"):
-            raise ValueError(f"model-trial case has no protected behavior contract: {case_id}")
-        cases[case_id] = case
-    if not cases:
-        raise ValueError("model-trial case contract is empty")
-    return cases
+    case_ids = cases_doc["case_ids"]
+    if not isinstance(case_ids, list) or not case_ids:
+        raise ValueError("model-trial case_ids must be a non-empty list")
+    if any(not isinstance(case_id, str) or not case_id for case_id in case_ids):
+        raise ValueError("every model-trial case_id must be a non-empty string")
+    if len(case_ids) != len(set(case_ids)):
+        raise ValueError("duplicate model-trial case_id")
+    return tuple(case_ids)
 
 
 def _nonnegative_int(value, field: str) -> int:
@@ -145,8 +159,10 @@ def one_sided_sign_test(differences: list[int]) -> dict:
     if non_ties == 0:
         p_value = 1.0
     else:
-        numerator = sum(math.comb(non_ties, k) for k in range(positive, non_ties + 1))
-        p_value = numerator / (2 ** non_ties)
+        p_value = (
+            sum(math.comb(non_ties, k) for k in range(positive, non_ties + 1))
+            / (2 ** non_ties)
+        )
     return {
         "positive": positive,
         "negative": negative,
@@ -157,16 +173,17 @@ def one_sided_sign_test(differences: list[int]) -> dict:
 
 
 def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
-    cases = validate_cases(cases_doc)
+    case_ids = validate_cases(cases_doc)
+    case_id_set = set(case_ids)
     if set(trials_doc) != REQUIRED_TRIAL_FIELDS:
         raise ValueError(
             f"model-trial result fields must be exactly {sorted(REQUIRED_TRIAL_FIELDS)}"
         )
-    if trials_doc.get("schema_version") != 1:
+    if trials_doc["schema_version"] != 1:
         raise ValueError("unsupported model-trial result schema_version")
-    if trials_doc.get("suite_id") != cases_doc["suite_id"]:
+    if trials_doc["suite_id"] != cases_doc["suite_id"]:
         raise ValueError("trial suite_id does not match case contract")
-    if trials_doc.get("evidence_kind") != "actual-model-runtime-ab":
+    if trials_doc["evidence_kind"] != "actual-model-runtime-ab":
         raise ValueError("trial evidence_kind must be actual-model-runtime-ab")
 
     baseline = trials_doc["baseline_representation"]
@@ -218,7 +235,7 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
         transcript_ref = row["transcript_ref"]
         if not isinstance(pair_id, str) or not pair_id:
             raise ValueError(f"run {run_id} requires pair_id")
-        if case_id not in cases:
+        if case_id not in case_id_set:
             raise ValueError(f"run {run_id} uses unknown case_id: {case_id}")
         if representation not in {"baseline", "candidate"}:
             raise ValueError(f"run {run_id} representation must be baseline or candidate")
@@ -258,7 +275,7 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
 
     errors: list[str] = []
     minimum = cases_doc["minimum_pairs_per_case"]
-    for case_id in cases:
+    for case_id in case_ids:
         count = len(pairs_by_case[case_id])
         if count < minimum:
             errors.append(f"case {case_id} has {count} pairs; requires at least {minimum}")
@@ -279,7 +296,8 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
     }
     per_case = {}
     differences = {metric: [] for metric in PRIMARY_METRICS}
-    for case_id, case_pairs in pairs_by_case.items():
+    for case_id in case_ids:
+        case_pairs = pairs_by_case[case_id]
         case_totals = {
             "baseline": {metric: 0 for metric in PRIMARY_METRICS},
             "candidate": {metric: 0 for metric in PRIMARY_METRICS},
@@ -326,19 +344,21 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
         "ok": not errors,
         "acceptance_errors": errors,
         "suite_id": cases_doc["suite_id"],
+        "semantic_case_contract": cases_doc["semantic_case_contract"],
         "evidence_kind": trials_doc["evidence_kind"],
         "baseline_ref": baseline_ref,
         "candidate_ref": candidate_ref,
         "runtime_identity": runtime_identity,
         "pair_count": len(pairs),
-        "pairs_per_case": {case_id: len(pairs_by_case[case_id]) for case_id in cases},
+        "pairs_per_case": {case_id: len(pairs_by_case[case_id]) for case_id in case_ids},
         "totals": totals,
         "per_case": per_case,
         "sign_tests": sign_tests,
         "improved_metrics": improved_metrics,
         "proof_boundary": (
-            "scores supplied observable paired records only; transcript authenticity, provider bias, "
-            "cross-model generalization, and semantic completeness still require evidence review"
+            "scores supplied observable paired records only; semantic case meaning remains owned by "
+            "the canonical Phase 7 runtime-optimization scenario contract; transcript authenticity, "
+            "provider bias, cross-model generalization, and semantic completeness still require review"
         ),
     }
 

--- a/tools/score_model_trials.py
+++ b/tools/score_model_trials.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Score paired observable A/B trials for runtime-representation candidates.
 
-This scorer never consumes or requests private chain-of-thought. It evaluates only
-explicit observable run records plus auditable transcript/tool-log references.
+This scorer never consumes or requests private chain-of-thought. It accepts only the
+closed observable evidence schema plus auditable transcript/tool-log references.
 """
 from __future__ import annotations
 
@@ -15,11 +15,30 @@ from pathlib import Path
 
 FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
 PROGRAM_BASELINE_REF = "f98e8a242c720931e34aa7c4e8a799090e3d0495"
+REQUIRED_TRIAL_FIELDS = {
+    "schema_version",
+    "suite_id",
+    "evidence_kind",
+    "baseline_representation",
+    "candidate_representation",
+    "runtime_identity",
+    "runs",
+}
+REQUIRED_REPRESENTATION_FIELDS = {"label", "ref"}
 REQUIRED_RUNTIME_IDENTITY = {
     "model_id",
     "model_version",
     "settings_fingerprint",
     "toolset_fingerprint",
+}
+REQUIRED_RUN_FIELDS = {
+    "run_id",
+    "pair_id",
+    "case_id",
+    "representation",
+    "order",
+    "transcript_ref",
+    "observed",
 }
 REQUIRED_OBSERVED_FIELDS = {
     "correct_next_action",
@@ -139,6 +158,10 @@ def one_sided_sign_test(differences: list[int]) -> dict:
 
 def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
     cases = validate_cases(cases_doc)
+    if set(trials_doc) != REQUIRED_TRIAL_FIELDS:
+        raise ValueError(
+            f"model-trial result fields must be exactly {sorted(REQUIRED_TRIAL_FIELDS)}"
+        )
     if trials_doc.get("schema_version") != 1:
         raise ValueError("unsupported model-trial result schema_version")
     if trials_doc.get("suite_id") != cases_doc["suite_id"]:
@@ -146,43 +169,53 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
     if trials_doc.get("evidence_kind") != "actual-model-runtime-ab":
         raise ValueError("trial evidence_kind must be actual-model-runtime-ab")
 
-    baseline = trials_doc.get("baseline_representation", {})
-    candidate = trials_doc.get("candidate_representation", {})
-    baseline_ref = baseline.get("ref", "")
-    candidate_ref = candidate.get("ref", "")
+    baseline = trials_doc["baseline_representation"]
+    candidate = trials_doc["candidate_representation"]
+    if not isinstance(baseline, dict) or set(baseline) != REQUIRED_REPRESENTATION_FIELDS:
+        raise ValueError("baseline_representation must contain exactly label and ref")
+    if not isinstance(candidate, dict) or set(candidate) != REQUIRED_REPRESENTATION_FIELDS:
+        raise ValueError("candidate_representation must contain exactly label and ref")
+    baseline_ref = baseline["ref"]
+    candidate_ref = candidate["ref"]
     if baseline_ref != cases_doc["baseline_ref"] or baseline_ref != PROGRAM_BASELINE_REF:
         raise ValueError("trial baseline representation does not match immutable program baseline")
     if not FULL_SHA_RE.fullmatch(candidate_ref) or candidate_ref == baseline_ref:
         raise ValueError("candidate representation must be a distinct exact full commit SHA")
-    if not baseline.get("label") or not candidate.get("label"):
-        raise ValueError("baseline and candidate representations require non-empty labels")
+    if not isinstance(baseline["label"], str) or not baseline["label"].strip():
+        raise ValueError("baseline representation requires a non-empty label")
+    if not isinstance(candidate["label"], str) or not candidate["label"].strip():
+        raise ValueError("candidate representation requires a non-empty label")
 
-    runtime_identity = trials_doc.get("runtime_identity", {})
-    if set(runtime_identity) != REQUIRED_RUNTIME_IDENTITY:
+    runtime_identity = trials_doc["runtime_identity"]
+    if not isinstance(runtime_identity, dict) or set(runtime_identity) != REQUIRED_RUNTIME_IDENTITY:
         raise ValueError(
             f"runtime_identity fields must be exactly {sorted(REQUIRED_RUNTIME_IDENTITY)}"
         )
     if any(not isinstance(value, str) or not value.strip() for value in runtime_identity.values()):
         raise ValueError("runtime_identity values must be non-empty strings")
 
-    runs = trials_doc.get("runs", [])
+    runs = trials_doc["runs"]
     if not isinstance(runs, list) or not runs:
         raise ValueError("model-trial results require runs")
 
     pair_rows: dict[str, list[dict]] = defaultdict(list)
     seen_run_ids: set[str] = set()
     for row in runs:
-        run_id = row.get("run_id")
+        if not isinstance(row, dict) or set(row) != REQUIRED_RUN_FIELDS:
+            raise ValueError(
+                f"every trial run must contain exactly {sorted(REQUIRED_RUN_FIELDS)}"
+            )
+        run_id = row["run_id"]
         if not isinstance(run_id, str) or not run_id:
             raise ValueError("every trial run requires a non-empty run_id")
         if run_id in seen_run_ids:
             raise ValueError(f"duplicate trial run_id: {run_id}")
         seen_run_ids.add(run_id)
-        pair_id = row.get("pair_id")
-        case_id = row.get("case_id")
-        representation = row.get("representation")
-        order = row.get("order")
-        transcript_ref = row.get("transcript_ref")
+        pair_id = row["pair_id"]
+        case_id = row["case_id"]
+        representation = row["representation"]
+        order = row["order"]
+        transcript_ref = row["transcript_ref"]
         if not isinstance(pair_id, str) or not pair_id:
             raise ValueError(f"run {run_id} requires pair_id")
         if case_id not in cases:
@@ -193,7 +226,7 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
             raise ValueError(f"run {run_id} order must be 1 or 2")
         if not isinstance(transcript_ref, str) or not transcript_ref.strip():
             raise ValueError(f"run {run_id} requires auditable transcript_ref")
-        observed = row.get("observed")
+        observed = row["observed"]
         if not isinstance(observed, dict):
             raise ValueError(f"run {run_id} requires observed object")
         validate_observed(observed, run_id)

--- a/tools/score_model_trials.py
+++ b/tools/score_model_trials.py
@@ -48,6 +48,7 @@ REQUIRED_RUN_FIELDS = {
     "run_id",
     "pair_id",
     "case_id",
+    "input_fingerprint",
     "representation",
     "order",
     "transcript_ref",
@@ -217,6 +218,7 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
 
     pair_rows: dict[str, list[dict]] = defaultdict(list)
     seen_run_ids: set[str] = set()
+    seen_transcript_refs: set[str] = set()
     for row in runs:
         if not isinstance(row, dict) or set(row) != REQUIRED_RUN_FIELDS:
             raise ValueError(
@@ -230,6 +232,7 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
         seen_run_ids.add(run_id)
         pair_id = row["pair_id"]
         case_id = row["case_id"]
+        input_fingerprint = row["input_fingerprint"]
         representation = row["representation"]
         order = row["order"]
         transcript_ref = row["transcript_ref"]
@@ -237,12 +240,17 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
             raise ValueError(f"run {run_id} requires pair_id")
         if case_id not in case_id_set:
             raise ValueError(f"run {run_id} uses unknown case_id: {case_id}")
+        if not isinstance(input_fingerprint, str) or not input_fingerprint.strip():
+            raise ValueError(f"run {run_id} requires non-empty input_fingerprint")
         if representation not in {"baseline", "candidate"}:
             raise ValueError(f"run {run_id} representation must be baseline or candidate")
         if order not in {1, 2}:
             raise ValueError(f"run {run_id} order must be 1 or 2")
         if not isinstance(transcript_ref, str) or not transcript_ref.strip():
             raise ValueError(f"run {run_id} requires auditable transcript_ref")
+        if transcript_ref in seen_transcript_refs:
+            raise ValueError(f"duplicate transcript_ref is not auditable per run: {transcript_ref}")
+        seen_transcript_refs.add(transcript_ref)
         observed = row["observed"]
         if not isinstance(observed, dict):
             raise ValueError(f"run {run_id} requires observed object")
@@ -262,6 +270,8 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
             raise ValueError(f"pair {pair_id} must use complementary order 1/2")
         if len({row["case_id"] for row in rows}) != 1:
             raise ValueError(f"pair {pair_id} must use one case_id")
+        if len({row["input_fingerprint"] for row in rows}) != 1:
+            raise ValueError(f"pair {pair_id} baseline/candidate inputs do not match")
         by_rep = {row["representation"]: row for row in rows}
         baseline_row = by_rep["baseline"]
         candidate_row = by_rep["candidate"]

--- a/tools/score_model_trials.py
+++ b/tools/score_model_trials.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Score paired observable A/B trials for runtime-representation candidates.
+
+This scorer never consumes or requests private chain-of-thought. It evaluates only
+explicit observable run records plus auditable transcript/tool-log references.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from collections import defaultdict
+from pathlib import Path
+
+FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
+PROGRAM_BASELINE_REF = "f98e8a242c720931e34aa7c4e8a799090e3d0495"
+REQUIRED_RUNTIME_IDENTITY = {
+    "model_id",
+    "model_version",
+    "settings_fingerprint",
+    "toolset_fingerprint",
+}
+REQUIRED_OBSERVED_FIELDS = {
+    "correct_next_action",
+    "protected_violations",
+    "steps_to_first_useful_action",
+    "unnecessary_questions",
+    "unnecessary_actions",
+    "unnecessary_reference_loads",
+    "manual_continue_required",
+}
+PRIMARY_METRICS = (
+    "protected_violation_count",
+    "decision_error",
+    "steps_to_first_useful_action",
+    "avoidable_events",
+)
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_cases(cases_doc: dict) -> dict[str, dict]:
+    if cases_doc.get("schema_version") != 1:
+        raise ValueError("unsupported model-trial case schema_version")
+    if cases_doc.get("suite_id") != "lossless-runtime-representation-v1":
+        raise ValueError("unexpected model-trial suite_id")
+    if cases_doc.get("baseline_ref") != PROGRAM_BASELINE_REF:
+        raise ValueError("model-trial baseline must remain pinned to v1.2.2 program baseline")
+    if cases_doc.get("evidence_kind") != "actual-model-runtime-ab":
+        raise ValueError("model-trial case contract must require actual-model-runtime-ab evidence")
+    if cases_doc.get("observable_only") is not True:
+        raise ValueError("model-trial contract must remain observable-only")
+    minimum = cases_doc.get("minimum_pairs_per_case")
+    if not isinstance(minimum, int) or isinstance(minimum, bool) or minimum < 1:
+        raise ValueError("minimum_pairs_per_case must be a positive integer")
+    alpha = cases_doc.get("sign_test_alpha")
+    if not isinstance(alpha, (int, float)) or isinstance(alpha, bool) or not (0 < alpha <= 0.5):
+        raise ValueError("sign_test_alpha must be in (0, 0.5]")
+    if tuple(cases_doc.get("primary_metrics", [])) != PRIMARY_METRICS:
+        raise ValueError("primary_metrics changed from the observable selection contract")
+
+    cases: dict[str, dict] = {}
+    for case in cases_doc.get("cases", []):
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id:
+            raise ValueError("every model-trial case requires a non-empty id")
+        if case_id in cases:
+            raise ValueError(f"duplicate model-trial case id: {case_id}")
+        if not case.get("protect"):
+            raise ValueError(f"model-trial case has no protected behavior contract: {case_id}")
+        cases[case_id] = case
+    if not cases:
+        raise ValueError("model-trial case contract is empty")
+    return cases
+
+
+def _nonnegative_int(value, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+def validate_observed(observed: dict, run_id: str) -> None:
+    if set(observed) != REQUIRED_OBSERVED_FIELDS:
+        raise ValueError(
+            f"run {run_id} observed fields must be exactly {sorted(REQUIRED_OBSERVED_FIELDS)}"
+        )
+    if not isinstance(observed["correct_next_action"], bool):
+        raise ValueError(f"run {run_id} correct_next_action must be boolean")
+    violations = observed["protected_violations"]
+    if not isinstance(violations, list) or any(
+        not isinstance(item, str) or not item.strip() for item in violations
+    ):
+        raise ValueError(f"run {run_id} protected_violations must be a list of non-empty strings")
+    _nonnegative_int(observed["steps_to_first_useful_action"], "steps_to_first_useful_action")
+    _nonnegative_int(observed["unnecessary_questions"], "unnecessary_questions")
+    _nonnegative_int(observed["unnecessary_actions"], "unnecessary_actions")
+    _nonnegative_int(observed["unnecessary_reference_loads"], "unnecessary_reference_loads")
+    if not isinstance(observed["manual_continue_required"], bool):
+        raise ValueError(f"run {run_id} manual_continue_required must be boolean")
+
+
+def run_metrics(run: dict) -> dict[str, int]:
+    observed = run["observed"]
+    return {
+        "protected_violation_count": len(observed["protected_violations"]),
+        "decision_error": 0 if observed["correct_next_action"] else 1,
+        "steps_to_first_useful_action": observed["steps_to_first_useful_action"],
+        "avoidable_events": (
+            observed["unnecessary_questions"]
+            + observed["unnecessary_actions"]
+            + observed["unnecessary_reference_loads"]
+            + int(observed["manual_continue_required"])
+        ),
+    }
+
+
+def one_sided_sign_test(differences: list[int]) -> dict:
+    """Exact H0 p=0.5 sign test where positive means candidate is better."""
+    positive = sum(1 for value in differences if value > 0)
+    negative = sum(1 for value in differences if value < 0)
+    non_ties = positive + negative
+    if non_ties == 0:
+        p_value = 1.0
+    else:
+        numerator = sum(math.comb(non_ties, k) for k in range(positive, non_ties + 1))
+        p_value = numerator / (2 ** non_ties)
+    return {
+        "positive": positive,
+        "negative": negative,
+        "ties": len(differences) - non_ties,
+        "non_ties": non_ties,
+        "p_value": p_value,
+    }
+
+
+def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
+    cases = validate_cases(cases_doc)
+    if trials_doc.get("schema_version") != 1:
+        raise ValueError("unsupported model-trial result schema_version")
+    if trials_doc.get("suite_id") != cases_doc["suite_id"]:
+        raise ValueError("trial suite_id does not match case contract")
+    if trials_doc.get("evidence_kind") != "actual-model-runtime-ab":
+        raise ValueError("trial evidence_kind must be actual-model-runtime-ab")
+
+    baseline = trials_doc.get("baseline_representation", {})
+    candidate = trials_doc.get("candidate_representation", {})
+    baseline_ref = baseline.get("ref", "")
+    candidate_ref = candidate.get("ref", "")
+    if baseline_ref != cases_doc["baseline_ref"] or baseline_ref != PROGRAM_BASELINE_REF:
+        raise ValueError("trial baseline representation does not match immutable program baseline")
+    if not FULL_SHA_RE.fullmatch(candidate_ref) or candidate_ref == baseline_ref:
+        raise ValueError("candidate representation must be a distinct exact full commit SHA")
+    if not baseline.get("label") or not candidate.get("label"):
+        raise ValueError("baseline and candidate representations require non-empty labels")
+
+    runtime_identity = trials_doc.get("runtime_identity", {})
+    if set(runtime_identity) != REQUIRED_RUNTIME_IDENTITY:
+        raise ValueError(
+            f"runtime_identity fields must be exactly {sorted(REQUIRED_RUNTIME_IDENTITY)}"
+        )
+    if any(not isinstance(value, str) or not value.strip() for value in runtime_identity.values()):
+        raise ValueError("runtime_identity values must be non-empty strings")
+
+    runs = trials_doc.get("runs", [])
+    if not isinstance(runs, list) or not runs:
+        raise ValueError("model-trial results require runs")
+
+    pair_rows: dict[str, list[dict]] = defaultdict(list)
+    seen_run_ids: set[str] = set()
+    for row in runs:
+        run_id = row.get("run_id")
+        if not isinstance(run_id, str) or not run_id:
+            raise ValueError("every trial run requires a non-empty run_id")
+        if run_id in seen_run_ids:
+            raise ValueError(f"duplicate trial run_id: {run_id}")
+        seen_run_ids.add(run_id)
+        pair_id = row.get("pair_id")
+        case_id = row.get("case_id")
+        representation = row.get("representation")
+        order = row.get("order")
+        transcript_ref = row.get("transcript_ref")
+        if not isinstance(pair_id, str) or not pair_id:
+            raise ValueError(f"run {run_id} requires pair_id")
+        if case_id not in cases:
+            raise ValueError(f"run {run_id} uses unknown case_id: {case_id}")
+        if representation not in {"baseline", "candidate"}:
+            raise ValueError(f"run {run_id} representation must be baseline or candidate")
+        if order not in {1, 2}:
+            raise ValueError(f"run {run_id} order must be 1 or 2")
+        if not isinstance(transcript_ref, str) or not transcript_ref.strip():
+            raise ValueError(f"run {run_id} requires auditable transcript_ref")
+        observed = row.get("observed")
+        if not isinstance(observed, dict):
+            raise ValueError(f"run {run_id} requires observed object")
+        validate_observed(observed, run_id)
+        pair_rows[pair_id].append(row)
+
+    pairs: list[tuple[dict, dict]] = []
+    pairs_by_case: dict[str, list[tuple[dict, dict]]] = defaultdict(list)
+    baseline_first_by_case: dict[str, int] = defaultdict(int)
+    candidate_first_by_case: dict[str, int] = defaultdict(int)
+    for pair_id, rows in sorted(pair_rows.items()):
+        if len(rows) != 2:
+            raise ValueError(f"pair {pair_id} must contain exactly two runs")
+        if {row["representation"] for row in rows} != {"baseline", "candidate"}:
+            raise ValueError(f"pair {pair_id} must contain one baseline and one candidate run")
+        if {row["order"] for row in rows} != {1, 2}:
+            raise ValueError(f"pair {pair_id} must use complementary order 1/2")
+        if len({row["case_id"] for row in rows}) != 1:
+            raise ValueError(f"pair {pair_id} must use one case_id")
+        by_rep = {row["representation"]: row for row in rows}
+        baseline_row = by_rep["baseline"]
+        candidate_row = by_rep["candidate"]
+        case_id = baseline_row["case_id"]
+        pairs.append((baseline_row, candidate_row))
+        pairs_by_case[case_id].append((baseline_row, candidate_row))
+        if baseline_row["order"] == 1:
+            baseline_first_by_case[case_id] += 1
+        else:
+            candidate_first_by_case[case_id] += 1
+
+    errors: list[str] = []
+    minimum = cases_doc["minimum_pairs_per_case"]
+    for case_id in cases:
+        count = len(pairs_by_case[case_id])
+        if count < minimum:
+            errors.append(f"case {case_id} has {count} pairs; requires at least {minimum}")
+        if count:
+            imbalance = abs(
+                baseline_first_by_case[case_id] - candidate_first_by_case[case_id]
+            )
+            if imbalance > 1:
+                errors.append(
+                    f"case {case_id} has materially unbalanced run order: "
+                    f"baseline-first={baseline_first_by_case[case_id]} "
+                    f"candidate-first={candidate_first_by_case[case_id]}"
+                )
+
+    totals = {
+        "baseline": {metric: 0 for metric in PRIMARY_METRICS},
+        "candidate": {metric: 0 for metric in PRIMARY_METRICS},
+    }
+    per_case = {}
+    differences = {metric: [] for metric in PRIMARY_METRICS}
+    for case_id, case_pairs in pairs_by_case.items():
+        case_totals = {
+            "baseline": {metric: 0 for metric in PRIMARY_METRICS},
+            "candidate": {metric: 0 for metric in PRIMARY_METRICS},
+        }
+        for baseline_row, candidate_row in case_pairs:
+            base_metrics = run_metrics(baseline_row)
+            cand_metrics = run_metrics(candidate_row)
+            for metric in PRIMARY_METRICS:
+                case_totals["baseline"][metric] += base_metrics[metric]
+                case_totals["candidate"][metric] += cand_metrics[metric]
+                totals["baseline"][metric] += base_metrics[metric]
+                totals["candidate"][metric] += cand_metrics[metric]
+                differences[metric].append(base_metrics[metric] - cand_metrics[metric])
+        per_case[case_id] = case_totals
+
+    if totals["candidate"]["protected_violation_count"] != 0:
+        errors.append("candidate has protected-behavior violations")
+
+    for case_id, case_totals in per_case.items():
+        for metric in PRIMARY_METRICS:
+            if case_totals["candidate"][metric] > case_totals["baseline"][metric]:
+                errors.append(
+                    f"candidate worsens {metric} in case {case_id}: "
+                    f"baseline={case_totals['baseline'][metric]} "
+                    f"candidate={case_totals['candidate'][metric]}"
+                )
+
+    sign_tests = {
+        metric: one_sided_sign_test(differences[metric]) for metric in PRIMARY_METRICS
+    }
+    alpha = cases_doc["sign_test_alpha"]
+    improved_metrics = [
+        metric
+        for metric in PRIMARY_METRICS
+        if totals["candidate"][metric] < totals["baseline"][metric]
+        and sign_tests[metric]["p_value"] <= alpha
+    ]
+    if not improved_metrics:
+        errors.append(
+            "candidate has no material paired observable improvement at configured sign-test alpha"
+        )
+
+    return {
+        "ok": not errors,
+        "acceptance_errors": errors,
+        "suite_id": cases_doc["suite_id"],
+        "evidence_kind": trials_doc["evidence_kind"],
+        "baseline_ref": baseline_ref,
+        "candidate_ref": candidate_ref,
+        "runtime_identity": runtime_identity,
+        "pair_count": len(pairs),
+        "pairs_per_case": {case_id: len(pairs_by_case[case_id]) for case_id in cases},
+        "totals": totals,
+        "per_case": per_case,
+        "sign_tests": sign_tests,
+        "improved_metrics": improved_metrics,
+        "proof_boundary": (
+            "scores supplied observable paired records only; transcript authenticity, provider bias, "
+            "cross-model generalization, and semantic completeness still require evidence review"
+        ),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cases",
+        type=Path,
+        default=Path("benchmarks/phase7/model-trial-cases.json"),
+    )
+    parser.add_argument("--trials", type=Path, required=True)
+    args = parser.parse_args()
+    result = evaluate(load(args.cases), load(args.trials))
+    print(json.dumps(result, indent=2, sort_keys=True))
+    raise SystemExit(0 if result["ok"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/score_phase7_benchmark.py
+++ b/tools/score_phase7_benchmark.py
@@ -173,7 +173,8 @@ def validate_trace_set(scenarios_doc, trace_doc):
         "goal_coverage": covered_goals,
         "version": version,
         "evidence_kind": trace_doc["evidence_kind"],
-        "proof_boundary": "source-grounded policy simulation; not independent model-performance evidence",
+        "optimization_claim_eligible": False,
+        "proof_boundary": "source-grounded policy simulation; not model-performance evidence",
     }
 
 def evaluate(scenarios_doc, baseline_doc, current_doc):
@@ -207,12 +208,11 @@ def evaluate(scenarios_doc, baseline_doc, current_doc):
     }
 
 def evaluate_candidate_pair(scenarios_doc, baseline_doc, candidate_doc):
-    """Compare an immutable current baseline with a candidate representation.
+    """Compare current source-grounded traces without making a performance claim.
 
-    Protected behavior is a hard gate. Every measured friction field must be non-worse,
-    and at least one decision-cost field must strictly improve. This does not turn the
-    source-grounded trace into real model-performance evidence; independent model/runtime
-    trials remain separately required by the optimization program.
+    This lane checks protected behavior and reports structural/friction diagnostics only.
+    It intentionally does not require, reward, or certify a synthetic trace reduction.
+    Practical optimization claims belong exclusively to paired actual model/runtime trials.
     """
     baseline_version = baseline_doc.get("version", "")
     candidate_version = candidate_doc.get("version", "")
@@ -225,30 +225,32 @@ def evaluate_candidate_pair(scenarios_doc, baseline_doc, candidate_doc):
     )
     acceptance_errors = protected_errors(scenarios, baseline_rows, candidate_rows)
     totals = {"baseline": totals_for(baseline_rows), "current": totals_for(candidate_rows)}
-    for field in FRICTION_FIELDS:
-        if totals["current"][field] > totals["baseline"][field]:
-            acceptance_errors.append(f"candidate worsened {field}")
-    material_fields = (
-        "steps_to_first_useful_action", "context_domains", "discovery_steps"
-    )
-    improved = [
-        field for field in material_fields
-        if totals["current"][field] < totals["baseline"][field]
+    deltas = {
+        field: totals["current"][field] - totals["baseline"][field]
+        for field in FRICTION_FIELDS
+    }
+    diagnostic_regressions = [
+        field for field, delta in deltas.items() if delta > 0
     ]
-    if not improved:
-        acceptance_errors.append(
-            "candidate shows no material source-grounded friction improvement"
-        )
+    diagnostic_reductions = [
+        field for field, delta in deltas.items() if delta < 0
+    ]
     return {
         "ok": not acceptance_errors,
         "acceptance_errors": acceptance_errors,
         "baseline": baseline_rows,
         "current": candidate_rows,
         "totals": totals,
-        "improved_material_fields": improved,
+        "diagnostic_deltas": deltas,
+        "diagnostic_regressions": diagnostic_regressions,
+        "diagnostic_reductions": diagnostic_reductions,
         "goal_coverage": covered_goals,
         "evidence_kind": "source-grounded-policy-simulation",
-        "proof_boundary": "does not prove independent LLM latency/quality improvement",
+        "optimization_claim_eligible": False,
+        "proof_boundary": (
+            "protected/source-grounded diagnostic comparison only; actual paired model/runtime "
+            "trial evidence is required for any practical-improvement claim"
+        ),
     }
 
 def main():


### PR DESCRIPTION
Parent: #35
Closes: #36 (Contract Revision 2)
Blocks/feeds: #37

## Why this correction exists

Phase B preparation exposed an evidence-model defect in the otherwise-successful Phase A integration #41.

#41 correctly labeled `traces-v1.2.2.json` as `source-grounded-policy-simulation`, but the new candidate scorer still required a strict reduction in hand-authored source-grounded friction before a representation candidate could pass. That is not valid proof of actual LLM improvement for a lossless representation program:

- if normative semantics remain identical, the prescribed correct path may legitimately remain identical;
- manually deleting a synthetic `classify`/`load` event can make a trace look faster without proving an LLM actually reasons faster, routes more accurately, or reconstructs less state;
- forcing a synthetic improvement creates exactly the benchmark-gaming pressure this program is intended to prevent.

## Corrected evidence model

This PR separates two roles mechanically and in documentation:

1. **Mechanical/source-grounded lane**
   - checks selected immutable semantic/protected-behavior invariants;
   - reports structural/friction/context diagnostics;
   - always reports `optimization_claim_eligible: false` for representation candidate traces;
   - does not require or certify synthetic trace reduction.

2. **Actual model/runtime A/B lane**
   - is the only lane eligible to satisfy the practical-improvement requirement;
   - uses paired same-case baseline/candidate runs;
   - requires exact baseline/candidate identities, equivalent model/runtime/settings/toolset identity, complementary/balanced run order, and auditable transcript/tool-log references;
   - scores only observable behavior and never requests/stores/scores private chain-of-thought;
   - hard-fails candidate protected-behavior violations and per-case primary-metric regressions;
   - requires at least one directional paired observable improvement at the configured exact one-sided sign-test threshold.

## Files

- add `benchmarks/phase7/MODEL-TRIAL-PROTOCOL.md`;
- add `benchmarks/phase7/model-trial-cases.json`;
- add `tools/score_model_trials.py`;
- add `tests/test_model_trial_scorer.py`;
- change `tools/score_phase7_benchmark.py` candidate mode to protected/diagnostic-only;
- update Phase 7 tests for the evidence boundary;
- lock evidence-role flags in `tests/test_runtime_equivalence.py`;
- update benchmark/design docs;
- add model-trial scorer fixtures to validation CI.

## Adversarial acceptance encoded in tests

The new actual-model evidence scorer must reject:

- identical/no-gain results as an optimization win;
- any candidate protected-behavior violation;
- wrong-next-action regression even if another metric improves;
- observable step regression in any case;
- materially unbalanced baseline-first/candidate-first order;
- incomplete pairs;
- missing audit/transcript references;
- model-trial baseline identity drift.

It accepts the positive fixture only when paired observable evidence improves without any configured protected regression.

The source-grounded candidate lane separately verifies that:

- identical traces are valid but not an optimization claim;
- a manually shortened trace is diagnostic only;
- protected violations still fail;
- a context-domain increase is reported diagnostically rather than falsely treated as measured model regression.

## Scope boundary

**No file under `skill/` changes in this PR.** This is an evidence/proof correction before Phase B prototypes.

No Rule ID, lifecycle state, authority gate, Worker/review/release/recovery behavior, version, or release is changed.

## Baselines

Immutable semantic/program baseline: `v1.2.2@f98e8a242c720931e34aa7c4e8a799090e3d0495`

Current integration target at branch start: `main@846ecf624aa07700fd4bbe32fd3e0d7f80373cda`

Contract Revision: 2
Risk: MEDIUM
Delivery Requirement: INTEGRATION_ONLY