### PR TITLE
Fix frozen screening model-trial scoring

### DIFF
--- a/tests/test_model_trial_scorer.py
+++ b/tests/test_model_trial_scorer.py
@@ -23,6 +23,21 @@ cases = json.loads(CASES_PATH.read_text(encoding="utf-8"))
 score.validate_cases(copy.deepcopy(cases))
 print("PASS model-trial-case-contract")
 
+if score.selected_case_ids(copy.deepcopy(cases), "screening") != score.SCREENING_CASE_IDS:
+    raise AssertionError("screening suite drifted from the frozen Phase B screening subset")
+if score.selected_case_ids(copy.deepcopy(cases), "selection") != tuple(cases["case_ids"]):
+    raise AssertionError("selection suite must remain the full canonical case set")
+print("PASS model-trial-suite-selection")
+
+try:
+    score.selected_case_ids(copy.deepcopy(cases), "custom")
+except ValueError as exc:
+    if "unsupported model-trial evaluation suite" not in str(exc):
+        raise
+    print("PASS arbitrary-suite-rejected")
+else:
+    raise AssertionError("arbitrary model-trial suite unexpectedly accepted")
+
 sign = score.one_sided_sign_test([1, 1, 1, 1, 1])
 if sign["p_value"] != 0.03125:
     raise AssertionError(sign)
@@ -41,9 +56,10 @@ def observed(*, refs: int = 0, steps: int = 5, correct: bool = True, violations=
     }
 
 
-def make_trials(*, improve_refs: bool = False) -> dict:
+def make_trials(*, improve_refs: bool = False, case_ids=None) -> dict:
     runs = []
-    for case_id in cases["case_ids"]:
+    selected = list(case_ids if case_ids is not None else cases["case_ids"])
+    for case_id in selected:
         for index in range(cases["minimum_pairs_per_case"]):
             pair_id = f"{case_id}-{index + 1}"
             input_fingerprint = f"input:{pair_id}:fixture-v1"
@@ -111,6 +127,36 @@ if not improved["ok"]:
 if "avoidable_events" not in improved["improved_metrics"]:
     raise AssertionError(improved)
 print("PASS observable-paired-improvement")
+
+screening_doc = make_trials(improve_refs=True, case_ids=score.SCREENING_CASE_IDS)
+screening = score.evaluate(copy.deepcopy(cases), copy.deepcopy(screening_doc), suite="screening")
+if not screening["ok"]:
+    raise AssertionError(screening)
+if screening["evaluated_case_ids"] != list(score.SCREENING_CASE_IDS):
+    raise AssertionError(screening)
+if screening["pair_count"] != len(score.SCREENING_CASE_IDS) * cases["minimum_pairs_per_case"]:
+    raise AssertionError(screening)
+print("PASS frozen-screening-subset-can-be-scored")
+
+selection_from_screening = score.evaluate(copy.deepcopy(cases), copy.deepcopy(screening_doc))
+if selection_from_screening["ok"] or not any(
+    "has 0 pairs" in error for error in selection_from_screening["acceptance_errors"]
+):
+    raise AssertionError("partial screening evidence unexpectedly satisfied full selection")
+print("PASS screening-does-not-satisfy-selection")
+
+screening_with_extra = copy.deepcopy(screening_doc)
+extra_case = next(case_id for case_id in cases["case_ids"] if case_id not in score.SCREENING_CASE_IDS)
+extra_pair = make_trials(improve_refs=True, case_ids=[extra_case])["runs"]
+screening_with_extra["runs"].extend(extra_pair)
+try:
+    score.evaluate(copy.deepcopy(cases), screening_with_extra, suite="screening")
+except ValueError as exc:
+    if "outside screening suite" not in str(exc):
+        raise
+    print("PASS screening-extra-case-rejected")
+else:
+    raise AssertionError("screening accepted a case outside the frozen subset")
 
 unsafe = copy.deepcopy(improved_doc)
 unsafe_candidate = next(row for row in unsafe["runs"] if row["representation"] == "candidate")
@@ -230,3 +276,14 @@ except ValueError as exc:
     print("PASS model-trial-baseline-drift-rejected")
 else:
     raise AssertionError("model-trial baseline drift unexpectedly accepted")
+
+missing_screening_case = copy.deepcopy(cases)
+missing_screening_case["case_ids"].remove(score.SCREENING_CASE_IDS[0])
+try:
+    score.validate_cases(missing_screening_case)
+except ValueError as exc:
+    if "frozen screening case" not in str(exc):
+        raise
+    print("PASS frozen-screening-case-drift-rejected")
+else:
+    raise AssertionError("canonical case set unexpectedly dropped a frozen screening case")

--- a/tools/score_model_trials.py
+++ b/tools/score_model_trials.py
@@ -16,6 +16,13 @@ from pathlib import Path
 FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
 PROGRAM_BASELINE_REF = "f98e8a242c720931e34aa7c4e8a799090e3d0495"
 SEMANTIC_CASE_CONTRACT = "benchmarks/phase7/runtime-optimization-scenarios.json"
+# Frozen first Phase B screening declared by decision-frame-v1. This is not a
+# free-form case selector: screening may score only this predeclared subset,
+# while selection still requires every canonical case in the manifest.
+SCREENING_CASE_IDS = (
+    "hot-fast-master-path",
+    "cold-master-recovery",
+)
 REQUIRED_CASE_CONTRACT_FIELDS = {
     "schema_version",
     "suite_id",
@@ -108,7 +115,18 @@ def validate_cases(cases_doc: dict) -> tuple[str, ...]:
         raise ValueError("every model-trial case_id must be a non-empty string")
     if len(case_ids) != len(set(case_ids)):
         raise ValueError("duplicate model-trial case_id")
+    if any(case_id not in case_ids for case_id in SCREENING_CASE_IDS):
+        raise ValueError("frozen screening case is missing from the canonical model-trial case set")
     return tuple(case_ids)
+
+
+def selected_case_ids(cases_doc: dict, suite: str) -> tuple[str, ...]:
+    all_case_ids = validate_cases(cases_doc)
+    if suite == "selection":
+        return all_case_ids
+    if suite == "screening":
+        return SCREENING_CASE_IDS
+    raise ValueError(f"unsupported model-trial evaluation suite: {suite}")
 
 
 def _nonnegative_int(value, field: str) -> int:
@@ -173,9 +191,11 @@ def one_sided_sign_test(differences: list[int]) -> dict:
     }
 
 
-def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
-    case_ids = validate_cases(cases_doc)
-    case_id_set = set(case_ids)
+def evaluate(cases_doc: dict, trials_doc: dict, *, suite: str = "selection") -> dict:
+    all_case_ids = validate_cases(cases_doc)
+    case_ids = selected_case_ids(cases_doc, suite)
+    all_case_id_set = set(all_case_ids)
+    selected_case_id_set = set(case_ids)
     if set(trials_doc) != REQUIRED_TRIAL_FIELDS:
         raise ValueError(
             f"model-trial result fields must be exactly {sorted(REQUIRED_TRIAL_FIELDS)}"
@@ -238,8 +258,10 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
         transcript_ref = row["transcript_ref"]
         if not isinstance(pair_id, str) or not pair_id:
             raise ValueError(f"run {run_id} requires pair_id")
-        if case_id not in case_id_set:
+        if case_id not in all_case_id_set:
             raise ValueError(f"run {run_id} uses unknown case_id: {case_id}")
+        if case_id not in selected_case_id_set:
+            raise ValueError(f"run {run_id} uses case outside {suite} suite: {case_id}")
         if not isinstance(input_fingerprint, str) or not input_fingerprint.strip():
             raise ValueError(f"run {run_id} requires non-empty input_fingerprint")
         if representation not in {"baseline", "candidate"}:
@@ -354,6 +376,8 @@ def evaluate(cases_doc: dict, trials_doc: dict) -> dict:
         "ok": not errors,
         "acceptance_errors": errors,
         "suite_id": cases_doc["suite_id"],
+        "evaluation_suite": suite,
+        "evaluated_case_ids": list(case_ids),
         "semantic_case_contract": cases_doc["semantic_case_contract"],
         "evidence_kind": trials_doc["evidence_kind"],
         "baseline_ref": baseline_ref,
@@ -381,8 +405,14 @@ def main() -> None:
         default=Path("benchmarks/phase7/model-trial-cases.json"),
     )
     parser.add_argument("--trials", type=Path, required=True)
+    parser.add_argument(
+        "--suite",
+        choices=("screening", "selection"),
+        default="selection",
+        help="score the frozen two-case screening subset or the full canonical selection suite",
+    )
     args = parser.parse_args()
-    result = evaluate(load(args.cases), load(args.trials))
+    result = evaluate(load(args.cases), load(args.trials), suite=args.suite)
     print(json.dumps(result, indent=2, sort_keys=True))
     raise SystemExit(0 if result["ok"] else 1)
 


### PR DESCRIPTION
## Outcome

Fixes a real mismatch in the optional model-trial tooling: the runner's frozen Phase B `screening` plan contains only `hot-fast-master-path` and `cold-master-recovery`, while the scorer previously required all eight canonical selection cases and therefore rejected a valid screening artifact for missing unrelated cases.

## Change

- add an explicit `screening|selection` evaluation mode to `tools/score_model_trials.py`;
- keep `selection` as the default and require all eight canonical cases there;
- freeze `screening` to exactly the predeclared two Phase B screening cases rather than accepting arbitrary case selection;
- reject canonical-but-out-of-screening cases when scoring screening evidence;
- report `evaluation_suite` and `evaluated_case_ids` in scorer output;
- extend adversarial fixtures so screening cannot masquerade as full selection or drift into a cherry-picked custom subset.

## Validation

Targeted scorer fixtures were executed in an isolated local container and passed, including existing safety/order/input/audit/private-reasoning guards plus new screening/selection boundary coverage.

## Scope guard

No canonical `skill/` runtime change, no VERSION/CHANGELOG change, no release intent, and no representation-selection claim. The model-trial lane remains optional tooling for future corroboration; this PR only makes the already-integrated tooling internally consistent.