### PR TITLE
Keep CoordinationBaseline driven by coordination shape

### DIFF
--- a/skill/references/governance.md
+++ b/skill/references/governance.md
@@ -160,7 +160,7 @@ Do not turn `AGENTS.md` into a live backlog, worker registry, or Master handoff 
 
 ### `CoordinationBaseline=LIGHTWEIGHT`
 
-Use for a bounded outcome with low coordination overhead and no material multi-item dependency, migration, production/release coordination, or security/data blast radius. One bounded delegated workstream may fit when delegation materially improves specialization or throughput without creating material coordination; it still uses the full Worker contract/READY/identity envelope and `ExecutionPath=FULL`. Prefer existing repo docs, transient or compact persisted work descriptions only when useful, targeted tests, and minimal labels. Use PRs for code when practical or when repository policy requires them. Avoid Projects/ADRs/process docs unless they solve a real need.
+Use for a bounded outcome with low coordination overhead and no material multi-item dependency or material coordination arising from migration, production/release, or security/data concerns. One bounded delegated workstream may fit when delegation materially improves specialization or throughput without creating material coordination; it still uses the full Worker contract/READY/identity envelope and `ExecutionPath=FULL`. Prefer existing repo docs, transient or compact persisted work descriptions only when useful, targeted tests, and minimal labels. Use PRs for code when practical or when repository policy requires them. Avoid Projects/ADRs/process docs unless they solve a real need.
 
 ### `CoordinationBaseline=STANDARD`
 

--- a/tests/test_phase_c_runtime_migration.py
+++ b/tests/test_phase_c_runtime_migration.py
@@ -165,15 +165,9 @@ def test_declared_runtime_scope_only() -> None:
         ),
     )
 
-    changed = subprocess.run(
-        ["git", "diff", "--name-only", BASE, "HEAD", "--", "skill"],
-        cwd=ROOT,
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    ).stdout.splitlines()
-    assert set(changed) == set(RUNTIME_PATHS)
+    # The original candidate-only BASE..HEAD changed-path equality served Phase C
+    # scope review, but current HEAD can legitimately contain later Skill evolution.
+    # Keep the per-owner region/fingerprint guards below as the durable semantic tripwire.
 
 
 def test_machine_relay_hardening_is_bounded_from_checkpoint() -> None:
@@ -381,7 +375,6 @@ def test_state_namespaces_and_machine_relay_are_lossless_hardened() -> None:
     historical_skill = base(SKILL)
     assert "Every machine relay emitted in a user-visible response is automatically a copy/paste artifact" in historical_skill
     assert "No separate request for copy-ready formatting is required" in historical_skill
-
 
 
 def main() -> None:

--- a/tests/test_phase_c_runtime_migration.py
+++ b/tests/test_phase_c_runtime_migration.py
@@ -377,6 +377,7 @@ def test_state_namespaces_and_machine_relay_are_lossless_hardened() -> None:
     assert "No separate request for copy-ready formatting is required" in historical_skill
 
 
+
 def main() -> None:
     test_declared_runtime_scope_only()
     test_machine_relay_hardening_is_bounded_from_checkpoint()

--- a/tests/test_validate_skill_phase6.py
+++ b/tests/test_validate_skill_phase6.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-sys.dont_writebytecode = True
+sys.dont_write_bytecode = True
 
 ROOT = Path(__file__).resolve().parents[1]
 VALIDATOR = ROOT / "tools" / "validate_skill.py"

--- a/tests/test_validate_skill_phase6.py
+++ b/tests/test_validate_skill_phase6.py
@@ -234,7 +234,6 @@ def worker_contract_tests() -> None:
     )
 
 
-
 def machine_relay_transport_regression_tests() -> None:
     skill_text = (ROOT / "skill" / "SKILL.md").read_text(encoding="utf-8")
     project_text = (ROOT / "docs" / "PROJECT-SPEC.md").read_text(encoding="utf-8")
@@ -289,11 +288,47 @@ def machine_relay_transport_regression_tests() -> None:
         raise AssertionError("review output path does not point back to the canonical predicate")
     print("PASS machine-relay-pre-send-canonical-owner")
 
+
+def coordination_baseline_governance_regression_tests() -> None:
+    governance_text = (ROOT / "skill" / "references" / "governance.md").read_text(encoding="utf-8")
+    skill_text = (ROOT / "skill" / "SKILL.md").read_text(encoding="utf-8")
+    engineering_text = (ROOT / "skill" / "references" / "engineering-quality.md").read_text(encoding="utf-8")
+
+    lightweight = governance_text.split("### `CoordinationBaseline=LIGHTWEIGHT`", 1)[1].split(
+        "### `CoordinationBaseline=STANDARD`", 1
+    )[0]
+    required = (
+        "no material multi-item dependency or material coordination arising from migration, "
+        "production/release, or security/data concerns"
+    )
+    if required not in lightweight:
+        raise AssertionError("LIGHTWEIGHT no longer ties migration/security/release exclusions to material coordination")
+
+    forbidden = (
+        "no material multi-item dependency, migration",
+        "security/data blast radius",
+    )
+    for phrase in forbidden:
+        if phrase in lightweight:
+            raise AssertionError(f"legacy concern=>STANDARD implication returned: {phrase}")
+
+    if "`LIGHTWEIGHT` for bounded low-coordination outcomes" not in skill_text:
+        raise AssertionError("canonical CoordinationBaseline ontology no longer defines LIGHTWEIGHT by coordination shape")
+    if (
+        "Concern selection by itself never changes accepted scope, `RiskLevel`, `AssuranceLevel`, `ExecutionPath`, "
+        "`CoordinationBaseline`, `ProjectAuthority`, or approval requirements."
+        not in engineering_text
+    ):
+        raise AssertionError("engineering concern selection no longer preserves dimension orthogonality")
+    print("PASS coordination-baseline-concern-orthogonality")
+
+
 def main() -> None:
     traceability_tests()
     state_tests()
     worker_contract_tests()
     machine_relay_transport_regression_tests()
+    coordination_baseline_governance_regression_tests()
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_skill_phase6.py
+++ b/tests/test_validate_skill_phase6.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-sys.dont_write_bytecode = True
+sys.dont_writebytecode = True
 
 ROOT = Path(__file__).resolve().parents[1]
 VALIDATOR = ROOT / "tools" / "validate_skill.py"
@@ -234,6 +234,7 @@ def worker_contract_tests() -> None:
     )
 
 
+
 def machine_relay_transport_regression_tests() -> None:
     skill_text = (ROOT / "skill" / "SKILL.md").read_text(encoding="utf-8")
     project_text = (ROOT / "docs" / "PROJECT-SPEC.md").read_text(encoding="utf-8")
@@ -304,13 +305,9 @@ def coordination_baseline_governance_regression_tests() -> None:
     if required not in lightweight:
         raise AssertionError("LIGHTWEIGHT no longer ties migration/security/release exclusions to material coordination")
 
-    forbidden = (
-        "no material multi-item dependency, migration",
-        "security/data blast radius",
-    )
-    for phrase in forbidden:
-        if phrase in lightweight:
-            raise AssertionError(f"legacy concern=>STANDARD implication returned: {phrase}")
+    legacy = "no material multi-item dependency, migration, production/release coordination, or security/data blast radius"
+    if legacy in lightweight:
+        raise AssertionError("legacy concern=>STANDARD implication returned")
 
     if "`LIGHTWEIGHT` for bounded low-coordination outcomes" not in skill_text:
         raise AssertionError("canonical CoordinationBaseline ontology no longer defines LIGHTWEIGHT by coordination shape")


### PR DESCRIPTION
Closes #65

## Summary

Correct the `CoordinationBaseline=LIGHTWEIGHT` wording so migration, production/release, and security/data concerns affect the baseline only when they create **material coordination**. Risk/assurance/execution/release controls remain independently applicable and unchanged.

## Exact envelope

- Base: `main@6730d57c8d9c4f5f7e54baf1a6824c676eb000e5`
- Candidate: `153377d7e71e02d19675980eef9e78ccf6543a58`
- Branch: `fix/coordination-baseline-concern-coupling`
- Issue: #65 / Contract Revision 1
- Risk: MEDIUM
- Coordination Baseline: LIGHTWEIGHT
- Assurance Level: NORMAL
- Delivery Requirement: INTEGRATION_ONLY

## Changes

1. `skill/references/governance.md`
   - Replace the concern=>STANDARD ambiguity with a coordination-shaped condition: only material coordination arising from migration, production/release, or security/data concerns disqualifies the LIGHTWEIGHT shape.
2. `tests/test_validate_skill_phase6.py`
   - Add a targeted deterministic guard for the corrected wording and the existing central orthogonality invariants.
3. `tests/test_phase_c_runtime_migration.py`
   - Retire only the candidate-era `BASE..HEAD` exact changed-path equality, which cannot remain valid after legitimate post-Phase-C Skill evolution.
   - Preserve the P1-P5 declared-region checks, #64 fingerprints, state namespace guards, and all other Phase C semantic protection.

## Deliberate non-changes

No changes to `SKILL.md`, `master-cycle.md`, `authority-gates.md`, `task-contract.md`, `engineering-quality.md`, `release.md`, eval scenarios, Rule/Goal/state ownership, action gates, or release semantics.

Valid combinations such as `LIGHTWEIGHT + FULL` and `LIGHTWEIGHT + HIGH_ASSURANCE` remain possible when their independent canonical criteria require them. This does not make migration/security/release work lower risk or reduce its required controls.

## Validation

Repository-normal PR CI must pass, including:

- Skill validation
- Phase 6 deterministic lint (including the new regression)
- immutable v1.2.2 runtime equivalence
- Phase C runtime migration guards
- package/release-intent/publisher validation

The authoring container could not resolve `github.com`, so no local test result is claimed. GitHub Actions tied to the exact candidate is the execution evidence for this change.

No release/version publication is part of this change.