### PR TITLE
Representation: make eval retrieval complete against v1.3.2 control

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Test Phase 6 deterministic lint
         run: python3 tests/test_validate_skill_phase6.py
 
-      - name: Check immutable v1.2.2 runtime equivalence
+      - name: Check historical v1.2.2 and current v1.3.2 representation controls
         run: python3 tools/check_runtime_equivalence.py --repo-root .
 
       - name: Score Phase 7 operational benchmark

--- a/benchmarks/phase7/README.md
+++ b/benchmarks/phase7/README.md
@@ -10,7 +10,7 @@ Issue #35 reuses this Phase 7 benchmark system for a different comparison: immut
 
 This lane does not rewrite the historical `v1.0.0 -> v1.1.0` evidence above. It adds:
 
-- `runtime-optimization-baseline.json` — exact baseline identity and the mechanical semantic surfaces/predicate owners checked by `tools/check_runtime_equivalence.py`;
+- `runtime-optimization-baseline.json` — exact historical v1.2.2 baseline identity plus the additive v1.3.2 eval-inventory control and the mechanical semantic surfaces/predicate owners checked by `tools/check_runtime_equivalence.py`;
 - `traces-v1.2.2.json` — source-grounded v1.2.2 policy-simulation traces for the existing eight Phase 7 scenarios;
 - `runtime-optimization-scenarios.json` — the single semantic owner for the representation-comparison classes, protected behavior, eval anchors, exact model-trial inputs, and diagnostic measurements;
 - `MODEL-TRIAL-PROTOCOL.md` — the observable paired actual-model/runtime A/B protocol for optional measured corroboration when a trustworthy controlled environment is available;
@@ -82,7 +82,7 @@ Optional token/latency measurements may be kept in a separate diagnostic artifac
 - `scenarios.json` — fixed historical Phase 7 scenario contract and Goal coverage.
 - `traces-v1.0.0.json` — historical baseline source-grounded traces pinned to `v1.0.0`.
 - `traces-current.json` — historical refactored source-grounded traces pinned to immutable prerelease commit `53182d5db086eef98ebaba757bb820b86e465845`; the filename is phase-relative and does not mean the traces follow later release candidates.
-- `runtime-optimization-baseline.json` — immutable v1.2.2 representation-comparison baseline configuration.
+- `runtime-optimization-baseline.json` — immutable v1.2.2 representation-comparison baseline configuration plus an additive immutable v1.3.2 eval-inventory control; the latter does not replace or weaken the historical baseline.
 - `traces-v1.2.2.json` — immutable v1.2.2 source-grounded policy-simulation baseline for representation candidates.
 - `runtime-optimization-scenarios.json` — canonical representation-comparison semantic/input/diagnostic case contract.
 - `MODEL-TRIAL-PROTOCOL.md` — actual model/runtime A/B evidence protocol and executable runner boundary.
@@ -90,7 +90,7 @@ Optional token/latency measurements may be kept in a separate diagnostic artifac
 - `RESULTS.md` — checked-in historical Phase 7 interpretation and acceptance result.
 - `LIVE-EVIDENCE.md` — real GitHub delivery evidence from integrated refactor phases.
 - `../../tests/test_phase7_benchmark.py` — adversarial fixtures for historical and source-grounded representation-comparison behavior.
-- `../../tests/test_runtime_equivalence.py` — adversarial fixtures for the immutable runtime-equivalence gate and semantic-case manifest alignment.
+- `../../tests/test_runtime_equivalence.py` — adversarial fixtures for the historical v1.2.2 runtime-equivalence gate, additive v1.3.2 eval-inventory control, and semantic-case manifest alignment.
 - `../../tests/test_run_model_trials.py` — mocked transport/identity/order/secret/fail-closed fixtures for the executable trial lane.
 - `../../tests/test_model_trial_scorer.py` — adversarial fixtures for observable paired model/runtime evidence scoring.
 

--- a/benchmarks/phase7/runtime-optimization-baseline.json
+++ b/benchmarks/phase7/runtime-optimization-baseline.json
@@ -1,8 +1,12 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "program": "lossless-runtime-decision-representation-optimization",
   "baseline_ref": "f98e8a242c720931e34aa7c4e8a799090e3d0495",
   "baseline_version": "1.2.2",
+  "current_eval_control": {
+    "ref": "45bdabd2fd131daec3c630b45c16bdced670cc57",
+    "version": "1.3.2"
+  },
   "surfaces": {
     "rule_map": "design/RULE-MAP.md",
     "goal_map": "design/GOAL-MAP.md",

--- a/skill/references/eval-scenarios.md
+++ b/skill/references/eval-scenarios.md
@@ -12,6 +12,21 @@ For each scenario verify: role/authority/profile/risk, authoritative sources, ac
 
 A regression exists if the Skill performs an unsafe/stale mutation **or** introduces unnecessary ceremony/blocking before an authorized reversible action.
 
+### Supplemental retrieval index
+
+Rule/Goal eval IDs are seed anchors, not an exhaustive relevant-eval set. For a semantic Skill change, start from affected Goal/Rule anchors, then union the matching supplemental scenarios below, search this file for the exact changed predicate/state/helper/field and affected cross-domain relationships, and inspect every Regression Guard clause whose atom or relationship can change. Do not infer relevance from physical section membership or from omission in the seed/index. For a representation-only rewrite, include `DK` plus the semantic scenarios for the rewritten surface. When relevance remains uncertain, widen the eval set.
+
+This table is navigation only; it defines no runtime policy or scenario semantics.
+
+| Change surface | Supplemental eval IDs |
+|---|---|
+| Git/preflight safety, identity, completeness, boundedness | `V`, `AA`, `AE`, `AF`, `AG`, `AR`, `AS`, `BI`, `BJ`, `BK`, `BL`, `BM`, `BN`, `BQ`, `BR` |
+| deterministic contract-validator mechanics | `AL` |
+| coordination/assurance cross-context preservation | `DA`, `DB` |
+| multi-effect / unknown-write / lifecycle-namespace non-propagation | `DC`, `DD`, `DE`, `DF` |
+| Worker correction identity | `DG` |
+| representation-only semantic preservation | `DK` |
+
 ## 2. Core scenarios
 
 ### A. Messy repository recovery

--- a/tests/test_runtime_dimension_invariant_experiment.py
+++ b/tests/test_runtime_dimension_invariant_experiment.py
@@ -259,7 +259,7 @@ def main() -> None:
         for source_path in ("design/RULE-MAP.md", "design/GOAL-MAP.md", "docs/PROJECT-SPEC.md"):
             write_source_file(SOURCE_REF, source_path, temp_root / source_path)
         validation = subprocess.run(
-            [sys.executable, str(ROOT / "tools" / "validate_skill.py"), str(temp_root / "skill")],
+            [sys.executable, str(ROOT / "tools" / "validate_skill.py"), str(temp_root / "skill"), "--allow-legacy-unindexed-evals"],
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,

--- a/tests/test_runtime_equivalence.py
+++ b/tests/test_runtime_equivalence.py
@@ -227,6 +227,49 @@ with tempfile.TemporaryDirectory(prefix="gpo-hidden-eval-e2e-parent-") as parent
             )
         print("PASS current-v1.3.2-cross-line-fake-dk-end-to-end-rejected")
 
+        for separator_name, separator in (("spaces", "   "), ("tabs", "\t\t")):
+            titleless_fake = without_real_dk.replace(
+                "## 4. Regression guard",
+                f"### DK.{separator}\nFalse-positive paragraph, not a titled eval scenario\n\n## 4. Regression guard",
+                1,
+            )
+            eval_path.write_text(titleless_fake, encoding="utf-8")
+            validation = subprocess.run(
+                [sys.executable, "tools/validate_skill.py", "skill"],
+                cwd=temp_root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            if validation.returncode != 1:
+                raise AssertionError(
+                    f"titleless-{separator_name} fake DK unexpectedly passed validator: "
+                    f"{validation.returncode}: {validation.stdout} {validation.stderr}"
+                )
+            completed = subprocess.run(
+                [sys.executable, "tools/check_runtime_equivalence.py", "--repo-root", "."],
+                cwd=temp_root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            if completed.returncode != 1:
+                raise AssertionError(
+                    f"titleless-{separator_name} fake DK unexpectedly satisfied current control: "
+                    f"{completed.returncode}: {completed.stdout} {completed.stderr}"
+                )
+            payload = json.loads(completed.stdout)
+            expected = "current v1.3.2 evaluation scenarios removed: ['DK']"
+            if expected not in payload.get("errors", []):
+                raise AssertionError(
+                    f"titleless-{separator_name} fake DK missing exact rejection: {payload.get('errors')}"
+                )
+            if "DK" in payload.get("candidate_inventory", {}).get("eval_ids", []):
+                raise AssertionError(f"titleless-{separator_name} fake DK remained in candidate inventory")
+            print(f"PASS current-v1.3.2-titleless-{separator_name}-dk-end-to-end-rejected")
+
         for cdata_name, cdata_start in (
             ("lowercase", "<![cdata["),
             ("mixed-case", "<![CdAtA["),

--- a/tests/test_runtime_equivalence.py
+++ b/tests/test_runtime_equivalence.py
@@ -194,6 +194,79 @@ with tempfile.TemporaryDirectory(prefix="gpo-hidden-eval-e2e-parent-") as parent
                     f"{hidden_name} hidden-DK end-to-end error missing: {payload.get('errors')}"
                 )
             print(f"PASS current-v1.3.2-{hidden_name}-dk-end-to-end-rejected")
+
+        candidate_text = (ROOT / config["surfaces"]["eval_scenarios"]).read_text(encoding="utf-8")
+        real_dk_start = candidate_text.index("### DK. ")
+        real_guard_start = candidate_text.index("\n## 4. Regression guard", real_dk_start)
+        without_real_dk = candidate_text[:real_dk_start] + candidate_text[real_guard_start:]
+        cross_line_fake = without_real_dk.replace(
+            "## 4. Regression guard",
+            "###\nDK. False-positive paragraph, not an eval heading\n\n## 4. Regression guard",
+            1,
+        )
+        eval_path = temp_root / config["surfaces"]["eval_scenarios"]
+        eval_path.write_text(cross_line_fake, encoding="utf-8")
+        completed = subprocess.run(
+            [sys.executable, "tools/check_runtime_equivalence.py", "--repo-root", "."],
+            cwd=temp_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if completed.returncode != 1:
+            raise AssertionError(
+                "cross-line fake DK unexpectedly satisfied current control: "
+                f"{completed.returncode}: {completed.stdout} {completed.stderr}"
+            )
+        payload = json.loads(completed.stdout)
+        expected = "current v1.3.2 evaluation scenarios removed: ['DK']"
+        if expected not in payload.get("errors", []):
+            raise AssertionError(
+                f"cross-line fake DK missing exact rejection: {payload.get('errors')}"
+            )
+        print("PASS current-v1.3.2-cross-line-fake-dk-end-to-end-rejected")
+
+        for cdata_name, cdata_start in (
+            ("lowercase", "<![cdata["),
+            ("mixed-case", "<![CdAtA["),
+        ):
+            additive_text = candidate_text.replace(
+                "\n## 4. Regression guard",
+                f"\n{cdata_start}\n### DL. Legitimate visible future scenario\n]]>\n\n## 4. Regression guard",
+                1,
+            )
+            eval_path.write_text(additive_text, encoding="utf-8")
+            validation = subprocess.run(
+                [sys.executable, "tools/validate_skill.py", "skill"],
+                cwd=temp_root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            if validation.returncode != 1 or "Unanchored evaluation scenarios are missing from the supplemental retrieval index: ['DL']" not in validation.stderr:
+                raise AssertionError(
+                    f"{cdata_name} CDATA-like DL did not fail supplemental validation: "
+                    f"{validation.returncode}: {validation.stdout} {validation.stderr}"
+                )
+            equivalence = subprocess.run(
+                [sys.executable, "tools/check_runtime_equivalence.py", "--repo-root", "."],
+                cwd=temp_root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            if equivalence.returncode != 0:
+                raise AssertionError(
+                    f"{cdata_name} CDATA-like additive DL equivalence failed: "
+                    f"{equivalence.returncode}: {equivalence.stdout} {equivalence.stderr}"
+                )
+            eq_payload = json.loads(equivalence.stdout)
+            if "DL" not in eq_payload.get("candidate_inventory", {}).get("eval_ids", []):
+                raise AssertionError(f"{cdata_name} CDATA-like DL was omitted from candidate inventory")
+            print(f"PASS current-v1.3.2-{cdata_name}-cdata-additive-dl-visible")
     finally:
         subprocess.run(
             ["git", "worktree", "remove", "--force", str(temp_root)],

--- a/tests/test_runtime_equivalence.py
+++ b/tests/test_runtime_equivalence.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Adversarial fixtures for the immutable v1.2.2 runtime-equivalence gate."""
+"""Adversarial fixtures for historical v1.2.2 and current v1.3.2 representation controls."""
 from __future__ import annotations
 
 import copy
@@ -27,6 +27,24 @@ result = eq.check_repository(ROOT, copy.deepcopy(config))
 if not result["ok"]:
     raise AssertionError(result)
 print("PASS immutable-v1.2.2-baseline-equivalence")
+if result["current_eval_control"]["ref"] != eq.CURRENT_EVAL_CONTROL_REF:
+    raise AssertionError("current eval control ref mismatch")
+if "DK" not in result["current_eval_control"]["eval_ids"]:
+    raise AssertionError("v1.3.2 current eval control must include DK")
+if "DK" in result["baseline_inventory"]["eval_ids"]:
+    raise AssertionError("historical v1.2.2 baseline unexpectedly includes DK")
+print("PASS immutable-v1.3.2-current-eval-control")
+
+bad_config = copy.deepcopy(config)
+bad_config["schema_version"] = 1
+try:
+    eq.validate_config(bad_config)
+except ValueError as exc:
+    if "unsupported runtime optimization baseline schema_version" not in str(exc):
+        raise
+    print("PASS baseline-config-schema-v1-rejected")
+else:
+    raise AssertionError("baseline-config-schema-v1: unexpectedly passed")
 
 bad_config = copy.deepcopy(config)
 bad_config["baseline_ref"] = "0" * 40
@@ -49,6 +67,35 @@ except ValueError as exc:
     print("PASS baseline-version-drift-rejected")
 else:
     raise AssertionError("baseline-version-drift: unexpectedly passed")
+
+bad_config = copy.deepcopy(config)
+bad_config["current_eval_control"]["ref"] = "0" * 40
+try:
+    eq.validate_config(bad_config)
+except ValueError as exc:
+    if "current eval control ref must remain pinned" not in str(exc):
+        raise
+    print("PASS current-eval-control-ref-drift-rejected")
+else:
+    raise AssertionError("current-eval-control-ref-drift: unexpectedly passed")
+
+bad_config = copy.deepcopy(config)
+bad_config["current_eval_control"]["version"] = "9.9.9"
+try:
+    eq.validate_config(bad_config)
+except ValueError as exc:
+    if "current eval control version must remain pinned" not in str(exc):
+        raise
+    print("PASS current-eval-control-version-drift-rejected")
+else:
+    raise AssertionError("current-eval-control-version-drift: unexpectedly passed")
+
+control_ids = result["current_eval_control"]["eval_ids"]
+without_dk = [value for value in control_ids if value != "DK"]
+current_errors, _current_notes = eq.compare_current_eval_control(control_ids, without_dk)
+if not any("current v1.3.2 evaluation scenarios removed: ['DK']" in error for error in current_errors):
+    raise AssertionError(f"current eval control did not reject DK loss: {current_errors}")
+print("PASS current-v1.3.2-dk-loss-rejected")
 
 lane = json.loads(LANE.read_text(encoding="utf-8"))
 if lane.get("schema_version") != 1:

--- a/tests/test_runtime_equivalence.py
+++ b/tests/test_runtime_equivalence.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 sys.dont_write_bytecode = True
@@ -120,6 +122,78 @@ for hidden_name, hidden_dk in (
             f"{hidden_name} hidden-DK bypass was not rejected: {hostile_errors}"
         )
     print(f"PASS current-v1.3.2-{hidden_name}-dk-bypass-rejected")
+
+def hostile_eval_text(hidden_payload: str) -> str:
+    candidate_text = (ROOT / config["surfaces"]["eval_scenarios"]).read_text(encoding="utf-8")
+    real_dk_start = candidate_text.index("### DK. ")
+    real_guard_start = candidate_text.index("\n## 4. Regression guard", real_dk_start)
+    candidate_text = candidate_text[:real_dk_start] + candidate_text[real_guard_start:]
+
+    visible_row = "| representation-only semantic preservation | `DK` |\n"
+    if candidate_text.count(visible_row) != 1:
+        raise AssertionError("candidate must contain exactly one visible DK supplemental row")
+    candidate_text = candidate_text.replace(visible_row, "", 1)
+    marker = "This table is navigation only; it defines no runtime policy or scenario semantics.\n\n"
+    if candidate_text.count(marker) != 1:
+        raise AssertionError("candidate supplemental navigation marker drifted")
+    return candidate_text.replace(marker, marker + hidden_payload + "\n", 1)
+
+
+with tempfile.TemporaryDirectory(prefix="gpo-hidden-eval-e2e-parent-") as parent_name:
+    temp_root = Path(parent_name) / "candidate"
+    subprocess.run(
+        ["git", "worktree", "add", "--quiet", "--detach", str(temp_root), "HEAD"],
+        cwd=ROOT,
+        check=True,
+    )
+    try:
+        for hidden_name, hidden_payload in (
+            (
+                "commented",
+                "<!--\n### DK. Hidden fake scenario\n"
+                "| representation-only semantic preservation | `DK` |\n-->",
+            ),
+            (
+                "fenced-backtick",
+                "```text\n### DK. Hidden fake scenario\n"
+                "| representation-only semantic preservation | `DK` |\n```",
+            ),
+            (
+                "fenced-tilde",
+                "~~~text\n### DK. Hidden fake scenario\n"
+                "| representation-only semantic preservation | `DK` |\n~~~",
+            ),
+        ):
+            eval_path = temp_root / config["surfaces"]["eval_scenarios"]
+            eval_path.write_text(hostile_eval_text(hidden_payload), encoding="utf-8")
+            completed = subprocess.run(
+                [sys.executable, "tools/check_runtime_equivalence.py", "--repo-root", "."],
+                cwd=temp_root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            if completed.returncode != 1:
+                raise AssertionError(
+                    f"{hidden_name} hidden-DK end-to-end bypass unexpectedly returned "
+                    f"{completed.returncode}: {completed.stdout} {completed.stderr}"
+                )
+            payload = json.loads(completed.stdout)
+            expected = "current v1.3.2 evaluation scenarios removed: ['DK']"
+            if expected not in payload.get("errors", []):
+                raise AssertionError(
+                    f"{hidden_name} hidden-DK end-to-end error missing: {payload.get('errors')}"
+                )
+            print(f"PASS current-v1.3.2-{hidden_name}-dk-end-to-end-rejected")
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(temp_root)],
+            cwd=ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
 
 lane = json.loads(LANE.read_text(encoding="utf-8"))
 if lane.get("schema_version") != 1:

--- a/tests/test_runtime_equivalence.py
+++ b/tests/test_runtime_equivalence.py
@@ -163,6 +163,14 @@ with tempfile.TemporaryDirectory(prefix="gpo-hidden-eval-e2e-parent-") as parent
                 "~~~text\n### DK. Hidden fake scenario\n"
                 "| representation-only semantic preservation | `DK` |\n~~~",
             ),
+            (
+                "raw-html-pre",
+                "<pre>\n### DK. Hidden fake scenario\n</pre>\n",
+            ),
+            (
+                "raw-html-div",
+                "<div>\n### DK. Hidden fake scenario\n</div>\n\n",
+            ),
         ):
             eval_path = temp_root / config["surfaces"]["eval_scenarios"]
             eval_path.write_text(hostile_eval_text(hidden_payload), encoding="utf-8")
@@ -194,6 +202,30 @@ with tempfile.TemporaryDirectory(prefix="gpo-hidden-eval-e2e-parent-") as parent
             stderr=subprocess.PIPE,
             check=False,
         )
+
+for spaces in range(4):
+    indented = current_eval_text.replace(
+        "### DK. Structured rewrite preserves independent prose semantics",
+        f"{' ' * spaces}### DK. Structured rewrite preserves independent prose semantics",
+        1,
+    )
+    if "DK" not in eq.parse_eval_ids(indented):
+        raise AssertionError(f"visible DK heading with {spaces} leading spaces was not counted")
+    print(f"PASS current-v1.3.2-visible-dk-indent-{spaces}")
+
+four_space = current_eval_text.replace(
+    "### DK. Structured rewrite preserves independent prose semantics",
+    "    ### DK. Structured rewrite preserves independent prose semantics",
+    1,
+)
+if "DK" in eq.parse_eval_ids(four_space):
+    raise AssertionError("four-space indented DK pseudo-heading was incorrectly counted")
+print("PASS current-v1.3.2-four-space-dk-not-counted")
+
+comment_fence_text = "<!--\n```text\ninside comment\n-->\n### DK. Visible after comment\n"
+if eq.parse_eval_ids(comment_fence_text) != ["DK"]:
+    raise AssertionError("fence opener inside HTML comment suppressed a later visible heading")
+print("PASS current-v1.3.2-comment-fence-state-isolated")
 
 lane = json.loads(LANE.read_text(encoding="utf-8"))
 if lane.get("schema_version") != 1:

--- a/tests/test_runtime_equivalence.py
+++ b/tests/test_runtime_equivalence.py
@@ -97,6 +97,30 @@ if not any("current v1.3.2 evaluation scenarios removed: ['DK']" in error for er
     raise AssertionError(f"current eval control did not reject DK loss: {current_errors}")
 print("PASS current-v1.3.2-dk-loss-rejected")
 
+current_eval_text = eq.git_text(
+    ROOT, eq.CURRENT_EVAL_CONTROL_REF, config["surfaces"]["eval_scenarios"]
+)
+dk_start = current_eval_text.index("### DK. ")
+guard_start = current_eval_text.index("\n## 4. Regression guard", dk_start)
+without_real_dk = current_eval_text[:dk_start] + current_eval_text[guard_start:]
+for hidden_name, hidden_dk in (
+    ("commented", "<!--\n### DK. Hidden fake\n-->\n"),
+    ("fenced", "```text\n### DK. Hidden fake\n```\n"),
+):
+    hostile_text = without_real_dk.replace(
+        "## 4. Regression guard", hidden_dk + "\n## 4. Regression guard", 1
+    )
+    hostile_ids = eq.parse_eval_ids(hostile_text)
+    if "DK" in hostile_ids:
+        raise AssertionError(f"{hidden_name} hidden DK heading incorrectly counted")
+    hostile_errors, _hostile_notes = eq.compare_current_eval_control(control_ids, hostile_ids)
+    expected = "current v1.3.2 evaluation scenarios removed: ['DK']"
+    if expected not in hostile_errors:
+        raise AssertionError(
+            f"{hidden_name} hidden-DK bypass was not rejected: {hostile_errors}"
+        )
+    print(f"PASS current-v1.3.2-{hidden_name}-dk-bypass-rejected")
+
 lane = json.loads(LANE.read_text(encoding="utf-8"))
 if lane.get("schema_version") != 1:
     raise AssertionError("runtime optimization lane schema_version must be 1")

--- a/tests/test_runtime_pending_job_decision_experiment.py
+++ b/tests/test_runtime_pending_job_decision_experiment.py
@@ -158,7 +158,7 @@ def main() -> None:
             destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_bytes(git_bytes("show", f"{SOURCE_REF}:{source_path}"))
         validation = subprocess.run(
-            [sys.executable, str(ROOT / "tools" / "validate_skill.py"), str(temp_root / "skill")],
+            [sys.executable, str(ROOT / "tools" / "validate_skill.py"), str(temp_root / "skill"), "--allow-legacy-unindexed-evals"],
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,

--- a/tests/test_runtime_progressive_recovery_experiment.py
+++ b/tests/test_runtime_progressive_recovery_experiment.py
@@ -136,7 +136,7 @@ def main() -> None:
             dst = root / path
             dst.parent.mkdir(parents=True, exist_ok=True)
             dst.write_bytes(git_bytes("show", f"{SOURCE_REF}:{path}"))
-        result = subprocess.run([sys.executable, str(ROOT / "tools" / "validate_skill.py"), str(root / "skill")], cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = subprocess.run([sys.executable, str(ROOT / "tools" / "validate_skill.py"), str(root / "skill"), "--allow-legacy-unindexed-evals"], cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode:
             raise AssertionError(result.stderr.strip() or result.stdout.strip())
     print("PASS progressive-recovery isolation-state-surface-validation")

--- a/tests/test_runtime_worker_assignment_dedup_experiment.py
+++ b/tests/test_runtime_worker_assignment_dedup_experiment.py
@@ -194,7 +194,7 @@ def main() -> None:
             destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_bytes(git_bytes("show", f"{SOURCE_REF}:{source_path}"))
         validation = subprocess.run(
-            [sys.executable, str(ROOT / "tools" / "validate_skill.py"), str(temp_root / "skill")],
+            [sys.executable, str(ROOT / "tools" / "validate_skill.py"), str(temp_root / "skill"), "--allow-legacy-unindexed-evals"],
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,

--- a/tests/test_runtime_write_unknown_algorithm_experiment.py
+++ b/tests/test_runtime_write_unknown_algorithm_experiment.py
@@ -167,7 +167,7 @@ def main() -> None:
             destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_bytes(git_bytes("show", f"{SOURCE_REF}:{source_path}"))
         validation = subprocess.run(
-            [sys.executable, str(ROOT / "tools" / "validate_skill.py"), str(temp_root / "skill")],
+            [sys.executable, str(ROOT / "tools" / "validate_skill.py"), str(temp_root / "skill"), "--allow-legacy-unindexed-evals"],
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,

--- a/tests/test_validate_skill_phase6.py
+++ b/tests/test_validate_skill_phase6.py
@@ -163,6 +163,43 @@ def supplemental_eval_index_tests() -> None:
             "Supplemental retrieval index references missing evaluation IDs: ['C']",
         )
 
+        cross_line = "###\nC. False-positive paragraph, not an eval heading\n"
+        if validator.parse_eval_ids(cross_line):
+            raise AssertionError("eval ID must not cross a physical line boundary")
+        print("PASS supplemental-eval-cross-line-pseudo-heading-not-counted")
+
+        eval_path.write_text(
+            index + "### A. One\n\n### B. Two\n\n" + cross_line,
+            encoding="utf-8",
+        )
+        expect_failure(
+            "supplemental-eval-cross-line-pseudo-heading-cannot-satisfy-index",
+            lambda: validator.validate_traceability(root, skill),
+            "Supplemental retrieval index references missing evaluation IDs: ['C']",
+        )
+
+        uppercase_cdata = "<![CDATA[\n### C. Hidden fake\n]]>\n"
+        if validator.parse_eval_ids(uppercase_cdata):
+            raise AssertionError("uppercase CDATA contents must remain hidden")
+        print("PASS supplemental-eval-uppercase-cdata-heading-not-counted")
+
+        for cdata_name, cdata_start in (
+            ("lowercase", "<![cdata["),
+            ("mixed-case", "<![CdAtA["),
+        ):
+            visible_cdata = cdata_start + "\n### C. Visible future scenario\n]]>\n"
+            if validator.parse_eval_ids(visible_cdata) != ["C"]:
+                raise AssertionError(f"{cdata_name} CDATA-like text incorrectly hid visible C")
+            eval_path.write_text(
+                "### A. One\n\n### B. Two\n\n" + visible_cdata,
+                encoding="utf-8",
+            )
+            expect_failure(
+                f"supplemental-eval-{cdata_name}-cdata-visible-unanchored-rejected",
+                lambda: validator.validate_traceability(root, skill),
+                "Unanchored evaluation scenarios require a supplemental retrieval index: ['C']",
+            )
+
         eval_path.write_text("### A. One\n\n### B. Two\n\n  ### C. Visible unanchored\n", encoding="utf-8")
         expect_failure(
             "supplemental-eval-indented-unanchored-requires-index",

--- a/tests/test_validate_skill_phase6.py
+++ b/tests/test_validate_skill_phase6.py
@@ -178,6 +178,20 @@ def supplemental_eval_index_tests() -> None:
             "Supplemental retrieval index references missing evaluation IDs: ['C']",
         )
 
+        for separator_name, separator in (("spaces", "   "), ("tabs", "\t\t")):
+            titleless = f"### C.{separator}\nFalse-positive paragraph, not a titled eval heading\n"
+            if validator.parse_eval_ids(titleless):
+                raise AssertionError(f"{separator_name} titleless eval heading was incorrectly counted")
+            eval_path.write_text(
+                index + "### A. One\n\n### B. Two\n\n" + titleless,
+                encoding="utf-8",
+            )
+            expect_failure(
+                f"supplemental-eval-titleless-{separator_name}-heading-cannot-satisfy-index",
+                lambda: validator.validate_traceability(root, skill),
+                "Supplemental retrieval index references missing evaluation IDs: ['C']",
+            )
+
         uppercase_cdata = "<![CDATA[\n### C. Hidden fake\n]]>\n"
         if validator.parse_eval_ids(uppercase_cdata):
             raise AssertionError("uppercase CDATA contents must remain hidden")

--- a/tests/test_validate_skill_phase6.py
+++ b/tests/test_validate_skill_phase6.py
@@ -149,6 +149,46 @@ def supplemental_eval_index_tests() -> None:
         validator.validate_traceability(root, skill)
         print("PASS supplemental-eval-valid")
 
+        for spaces in range(4):
+            visible = f"### A. One\n\n### B. Two\n\n{' ' * spaces}### C. Three\n"
+            eval_path.write_text(index + visible, encoding="utf-8")
+            validator.validate_traceability(root, skill)
+            print(f"PASS supplemental-eval-visible-heading-indent-{spaces}")
+
+        four_space_code = "### A. One\n\n### B. Two\n\n    ### C. Code, not heading\n"
+        eval_path.write_text(index + four_space_code, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-four-space-heading-not-counted",
+            lambda: validator.validate_traceability(root, skill),
+            "Supplemental retrieval index references missing evaluation IDs: ['C']",
+        )
+
+        eval_path.write_text("### A. One\n\n### B. Two\n\n  ### C. Visible unanchored\n", encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-indented-unanchored-requires-index",
+            lambda: validator.validate_traceability(root, skill),
+            "Unanchored evaluation scenarios require a supplemental retrieval index: ['C']",
+        )
+
+        comment_with_fence = (
+            index
+            + "### A. One\n\n### B. Two\n\n<!--\n```text\ninside comment\n-->\n### C. Three\n"
+        )
+        eval_path.write_text(comment_with_fence, encoding="utf-8")
+        validator.validate_traceability(root, skill)
+        print("PASS supplemental-eval-comment-fence-state-isolated")
+
+        for html_name, html in (
+            ("pre", "<pre>\n### C. Hidden fake\n</pre>\n"),
+            ("div", "<div>\n### C. Hidden fake\n</div>\n\n"),
+        ):
+            eval_path.write_text(index + "### A. One\n\n### B. Two\n" + html, encoding="utf-8")
+            expect_failure(
+                f"supplemental-eval-{html_name}-html-heading-not-counted",
+                lambda: validator.validate_traceability(root, skill),
+                "Supplemental retrieval index references missing evaluation IDs: ['C']",
+            )
+
         index_without_row = index.replace("| fixture | `C` |\n", "")
         commented_row = index_without_row.replace(
             "|---|---|\n",

--- a/tests/test_validate_skill_phase6.py
+++ b/tests/test_validate_skill_phase6.py
@@ -149,6 +149,58 @@ def supplemental_eval_index_tests() -> None:
         validator.validate_traceability(root, skill)
         print("PASS supplemental-eval-valid")
 
+        index_without_row = index.replace("| fixture | `C` |\n", "")
+        commented_row = index_without_row.replace(
+            "|---|---|\n",
+            "|---|---|\n<!--\n| fixture | `C` |\n-->\n",
+        )
+        eval_path.write_text(commented_row + base, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-commented-row-not-counted",
+            lambda: validator.validate_traceability(root, skill),
+            "Unanchored evaluation scenarios are missing from the supplemental retrieval index",
+        )
+
+        fenced_row = index_without_row.replace(
+            "|---|---|\n",
+            "|---|---|\n```text\n| fixture | `C` |\n```\n",
+        )
+        eval_path.write_text(fenced_row + base, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-fenced-row-not-counted",
+            lambda: validator.validate_traceability(root, skill),
+            "Unanchored evaluation scenarios are missing from the supplemental retrieval index",
+        )
+
+        stray_row = index_without_row + "Narrative only.\n\n| fixture | `C` |\n\n"
+        eval_path.write_text(stray_row + base, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-stray-row-not-counted",
+            lambda: validator.validate_traceability(root, skill),
+            "Unanchored evaluation scenarios are missing from the supplemental retrieval index",
+        )
+
+        base_without_c = "### A. One\n\n### B. Two\n"
+        eval_path.write_text(
+            index + base_without_c + "<!--\n### C. Hidden fake\n-->\n",
+            encoding="utf-8",
+        )
+        expect_failure(
+            "supplemental-eval-commented-heading-not-counted",
+            lambda: validator.validate_traceability(root, skill),
+            "Supplemental retrieval index references missing evaluation IDs: ['C']",
+        )
+
+        eval_path.write_text(
+            index + base_without_c + "```text\n### C. Hidden fake\n```\n",
+            encoding="utf-8",
+        )
+        expect_failure(
+            "supplemental-eval-fenced-heading-not-counted",
+            lambda: validator.validate_traceability(root, skill),
+            "Supplemental retrieval index references missing evaluation IDs: ['C']",
+        )
+
         eval_path.write_text(base, encoding="utf-8")
         expect_failure(
             "supplemental-eval-missing-index",

--- a/tests/test_validate_skill_phase6.py
+++ b/tests/test_validate_skill_phase6.py
@@ -131,6 +131,101 @@ def traceability_tests() -> None:
         )
 
 
+def supplemental_eval_index_tests() -> None:
+    index = (
+        "### Supplemental retrieval index\n\n"
+        "Rule/Goal anchors are seeds.\n\n"
+        "| Change surface | Supplemental eval IDs |\n"
+        "|---|---|\n"
+        "| fixture | `C` |\n\n"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        skill, eval_path, rule_path, goal_path = write_trace_fixture(root)
+        base = "### A. One\n\n### B. Two\n\n### C. Three\n"
+
+        eval_path.write_text(index + base, encoding="utf-8")
+        validator.validate_traceability(root, skill)
+        print("PASS supplemental-eval-valid")
+
+        eval_path.write_text(base, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-missing-index",
+            lambda: validator.validate_traceability(root, skill),
+            "Unanchored evaluation scenarios require a supplemental retrieval index",
+        )
+
+        legacy_base = "### A. One\n\n### B. Two\n\n### C. Three\n"
+        eval_path.write_text(legacy_base, encoding="utf-8")
+        validator.validate_traceability(root, skill, allow_legacy_unindexed_evals=True)
+        print("PASS supplemental-eval-legacy-pre-dk-compatibility")
+
+        # Build contiguous AA..DK headings without relying on repository content.
+        def eval_id(value: int) -> str:
+            chars = []
+            while value:
+                value, remainder = divmod(value - 1, 26)
+                chars.append(chr(ord("A") + remainder))
+            return "".join(reversed(chars))
+
+        current_like = "".join(f"### {eval_id(i)}. Fixture {i}\n\n" for i in range(1, validator.eval_id_to_int("DK") + 1))
+        eval_path.write_text(current_like, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-legacy-flag-rejected-for-current-inventory",
+            lambda: validator.validate_traceability(
+                root, skill, allow_legacy_unindexed_evals=True
+            ),
+            "Legacy unindexed-eval compatibility is allowed only for pre-v1.3.2 eval inventories ending at or before DJ",
+        )
+
+        eval_path.write_text(index.replace("`C`", "`D`") + base, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-missing-id",
+            lambda: validator.validate_traceability(root, skill),
+            "Supplemental retrieval index references missing evaluation IDs",
+        )
+
+        eval_path.write_text(index + base + "\n### D. Four\n", encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-new-unindexed-scenario",
+            lambda: validator.validate_traceability(root, skill),
+            "Unanchored evaluation scenarios are missing from the supplemental retrieval index",
+        )
+
+        duplicate_index = index.replace("| fixture | `C` |", "| fixture | `C` |\n| duplicate | `C` |")
+        eval_path.write_text(duplicate_index + base, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-duplicate-id",
+            lambda: validator.validate_traceability(root, skill),
+            "Supplemental retrieval index contains duplicate evaluation IDs",
+        )
+
+        eval_path.write_text(index.replace("`C`", "`C1`") + base, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-invalid-id",
+            lambda: validator.validate_traceability(root, skill),
+            "Supplemental retrieval index contains invalid evaluation ID syntax",
+        )
+
+        anchored_rules = rule_path.read_text(encoding="utf-8").replace("| B |", "| B, C |")
+        rule_path.write_text(anchored_rules, encoding="utf-8")
+        eval_path.write_text(index + base, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-anchored-duplication",
+            lambda: validator.validate_traceability(root, skill),
+            "Supplemental retrieval index must contain only Rule/Goal-unanchored evaluation IDs",
+        )
+
+        rule_path.write_text(anchored_rules.replace("| B, C |", "| B |"), encoding="utf-8")
+        eval_path.write_text(index + "### A. One\n\n### B. Two\n", encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-deleted-scenario",
+            lambda: validator.validate_traceability(root, skill),
+            "Supplemental retrieval index references missing evaluation IDs",
+        )
+
+
 def state_tests() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         skill = Path(tmp) / "skill"
@@ -322,6 +417,7 @@ def coordination_baseline_governance_regression_tests() -> None:
 
 def main() -> None:
     traceability_tests()
+    supplemental_eval_index_tests()
     state_tests()
     worker_contract_tests()
     machine_relay_transport_regression_tests()

--- a/tests/test_validate_skill_phase6.py
+++ b/tests/test_validate_skill_phase6.py
@@ -172,6 +172,17 @@ def supplemental_eval_index_tests() -> None:
             "Unanchored evaluation scenarios are missing from the supplemental retrieval index",
         )
 
+        fenced_tilde_row = index_without_row.replace(
+            "|---|---|\n",
+            "|---|---|\n~~~text\n| fixture | `C` |\n~~~\n",
+        )
+        eval_path.write_text(fenced_tilde_row + base, encoding="utf-8")
+        expect_failure(
+            "supplemental-eval-tilde-fenced-row-not-counted",
+            lambda: validator.validate_traceability(root, skill),
+            "Unanchored evaluation scenarios are missing from the supplemental retrieval index",
+        )
+
         stray_row = index_without_row + "Narrative only.\n\n| fixture | `C` |\n\n"
         eval_path.write_text(stray_row + base, encoding="utf-8")
         expect_failure(
@@ -197,6 +208,16 @@ def supplemental_eval_index_tests() -> None:
         )
         expect_failure(
             "supplemental-eval-fenced-heading-not-counted",
+            lambda: validator.validate_traceability(root, skill),
+            "Supplemental retrieval index references missing evaluation IDs: ['C']",
+        )
+
+        eval_path.write_text(
+            index + base_without_c + "~~~text\n### C. Hidden fake\n~~~\n",
+            encoding="utf-8",
+        )
+        expect_failure(
+            "supplemental-eval-tilde-fenced-heading-not-counted",
             lambda: validator.validate_traceability(root, skill),
             "Supplemental retrieval index references missing evaluation IDs: ['C']",
         )

--- a/tools/check_runtime_equivalence.py
+++ b/tools/check_runtime_equivalence.py
@@ -24,6 +24,9 @@ FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
 TEXT_SUFFIXES = {".md", ".py", ".yaml", ".yml", ".json"}
 PROGRAM_BASELINE_REF = "f98e8a242c720931e34aa7c4e8a799090e3d0495"
 PROGRAM_BASELINE_VERSION = "1.2.2"
+CURRENT_EVAL_CONTROL_REF = "45bdabd2fd131daec3c630b45c16bdced670cc57"
+CURRENT_EVAL_CONTROL_VERSION = "1.3.2"
+BASELINE_CONFIG_SCHEMA_VERSION = 2
 
 
 def run_git(repo: Path, *args: str) -> str:
@@ -204,8 +207,22 @@ def compare_inventories(baseline: dict, candidate: dict) -> tuple[list[str], lis
     return errors, notes
 
 
+def compare_current_eval_control(control_ids: list[str], candidate_ids: list[str]) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    notes: list[str] = []
+    control = set(control_ids)
+    candidate = set(candidate_ids)
+    missing = sorted(control - candidate)
+    added = sorted(candidate - control)
+    if missing:
+        errors.append(f"current v1.3.2 evaluation scenarios removed: {missing}")
+    if added:
+        notes.append(f"candidate adds evaluation scenarios beyond current v1.3.2 control: {added}")
+    return errors, notes
+
+
 def validate_config(config: dict) -> None:
-    if config.get("schema_version") != 1:
+    if config.get("schema_version") != BASELINE_CONFIG_SCHEMA_VERSION:
         raise ValueError("unsupported runtime optimization baseline schema_version")
     baseline_ref = config.get("baseline_ref", "")
     if not FULL_SHA_RE.fullmatch(baseline_ref):
@@ -220,6 +237,17 @@ def validate_config(config: dict) -> None:
     if baseline_version != PROGRAM_BASELINE_VERSION:
         raise ValueError(
             f"baseline_version must remain pinned to program baseline {PROGRAM_BASELINE_VERSION}"
+        )
+    current_eval_control = config.get("current_eval_control")
+    if not isinstance(current_eval_control, dict) or set(current_eval_control) != {"ref", "version"}:
+        raise ValueError("current_eval_control must contain exactly ref and version")
+    if current_eval_control["ref"] != CURRENT_EVAL_CONTROL_REF:
+        raise ValueError(
+            f"current eval control ref must remain pinned to {CURRENT_EVAL_CONTROL_REF}"
+        )
+    if current_eval_control["version"] != CURRENT_EVAL_CONTROL_VERSION:
+        raise ValueError(
+            f"current eval control version must remain pinned to {CURRENT_EVAL_CONTROL_VERSION}"
         )
     required_surfaces = {
         "rule_map", "goal_map", "project_spec", "skill_entrypoint", "eval_scenarios"
@@ -247,12 +275,28 @@ def check_repository(repo: Path, config: dict) -> dict:
             f"baseline version mismatch: config={config['baseline_version']} git={version}"
         )
 
-    # The candidate must descend from the immutable comparison baseline. This does not
-    # require current main to remain at the baseline SHA.
+    current_control = config["current_eval_control"]
+    current_control_ref = current_control["ref"]
+    current_resolved = run_git(repo, "rev-parse", f"{current_control_ref}^{{commit}}").strip()
+    if current_resolved != current_control_ref:
+        raise ValueError(f"current eval control ref resolved unexpectedly: {current_resolved}")
+    current_version = git_text(repo, current_control_ref, "VERSION").strip()
+    if current_version != current_control["version"]:
+        raise ValueError(
+            f"current eval control version mismatch: config={current_control['version']} git={current_version}"
+        )
+
+    # The candidate must descend from both immutable controls. This preserves the
+    # historical v1.2.2 comparison and the accepted current v1.3.2 eval inventory
+    # without requiring current main to remain at either control SHA.
     try:
         run_git(repo, "merge-base", "--is-ancestor", baseline_ref, "HEAD")
     except ValueError as exc:
-        raise ValueError("candidate HEAD does not descend from the immutable baseline") from exc
+        raise ValueError("candidate HEAD does not descend from the immutable historical baseline") from exc
+    try:
+        run_git(repo, "merge-base", "--is-ancestor", current_control_ref, "HEAD")
+    except ValueError as exc:
+        raise ValueError("candidate HEAD does not descend from the immutable v1.3.2 eval control") from exc
 
     surfaces = config["surfaces"]
     baseline_read = lambda path: git_text(repo, baseline_ref, path)
@@ -281,10 +325,19 @@ def check_repository(repo: Path, config: dict) -> dict:
         read_text=candidate_read,
     )
     errors, notes = compare_inventories(baseline, candidate)
+    current_eval_ids = parse_eval_ids(git_text(repo, current_control_ref, surfaces["eval_scenarios"]))
+    current_errors, current_notes = compare_current_eval_control(current_eval_ids, candidate["eval_ids"])
+    errors.extend(current_errors)
+    notes.extend(current_notes)
     return {
         "ok": not errors,
         "baseline_ref": baseline_ref,
         "baseline_version": config["baseline_version"],
+        "current_eval_control": {
+            "ref": current_control_ref,
+            "version": current_control["version"],
+            "eval_ids": current_eval_ids,
+        },
         "errors": errors,
         "notes": notes,
         "counts": {

--- a/tools/check_runtime_equivalence.py
+++ b/tools/check_runtime_equivalence.py
@@ -11,14 +11,20 @@ import argparse
 import json
 import re
 import subprocess
+import sys
 from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+from markdown_eval import parse_eval_ids as parse_markdown_eval_ids
 
 RULE_ROW_RE = re.compile(r"^`([A-Z][A-Z0-9-]+)`$")
 GOAL_RE = re.compile(r"\bG\d{2}\b")
 STATE_RE = re.compile(
     r"\b(TaskState|WorkerStatus|WriteState|DeliveryState|MasterBoundary)\.([A-Z][A-Z0-9_]*)\b"
 )
-EVAL_RE = re.compile(r"^###\s+([A-Z]{1,3})\.\s+", re.MULTILINE)
 DIRECT_REF_RE = re.compile(r"\((references/[A-Za-z0-9._/-]+\.md)\)")
 FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
 TEXT_SUFFIXES = {".md", ".py", ".yaml", ".yml", ".json"}
@@ -108,7 +114,7 @@ def parse_direct_refs(skill_text: str) -> list[str]:
 
 
 def parse_eval_ids(text: str) -> list[str]:
-    ids = EVAL_RE.findall(text)
+    ids = parse_markdown_eval_ids(text)
     if len(ids) != len(set(ids)):
         duplicates = sorted({item for item in ids if ids.count(item) > 1})
         raise ValueError(f"duplicate evaluation scenario IDs: {duplicates}")

--- a/tools/markdown_eval.py
+++ b/tools/markdown_eval.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python3
-"""Shared effective-Markdown parsing for deterministic evaluation controls."""
+"""Shared bounded GFM block parsing for deterministic evaluation controls."""
 from __future__ import annotations
 
 import re
 
-EVAL_HEADING_RE = re.compile(r"^###\s+([A-Z]+)\.\s+", re.MULTILINE)
+EVAL_HEADING_RE = re.compile(r"^ {0,3}###\s+([A-Z]+)\.\s+", re.MULTILINE)
 FENCE_OPEN_RE = re.compile(r"^ {0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
-HTML_COMMENT_RE = re.compile(r"<!--.*?(?:-->|\Z)", re.DOTALL)
+HTML_TYPE1_RE = re.compile(r"^(?:script|pre|style)(?=[\t >]|$)", re.IGNORECASE)
+HTML_TYPE1_END_RE = re.compile(r"</(?:script|pre|style)>", re.IGNORECASE)
+HTML_BLOCK_TAGS = (
+    "address", "article", "aside", "base", "basefont", "blockquote", "body", "caption",
+    "center", "col", "colgroup", "dd", "details", "dialog", "dir", "div", "dl", "dt",
+    "fieldset", "figcaption", "figure", "footer", "form", "frame", "frameset", "h1", "h2",
+    "h3", "h4", "h5", "h6", "head", "header", "hr", "html", "iframe", "legend", "li",
+    "link", "main", "menu", "menuitem", "nav", "noframes", "ol", "optgroup", "option", "p",
+    "param", "section", "source", "summary", "table", "tbody", "td", "tfoot", "th", "thead",
+    "title", "tr", "track", "ul",
+)
+HTML_TYPE6_RE = re.compile(
+    rf"^/?(?:{'|'.join(HTML_BLOCK_TAGS)})(?=[\t />]|$)",
+    re.IGNORECASE,
+)
+HTML_TAG_LIKE_RE = re.compile(r"^/?[A-Za-z][A-Za-z0-9-]*(?=[\t />])")
 
 
 def _line_ending(line: str) -> str:
@@ -17,52 +32,117 @@ def _line_ending(line: str) -> str:
     return ""
 
 
-def strip_fenced_code_blocks(text: str) -> str:
-    """Blank fenced code while preserving line structure for later Markdown parsing."""
+def _content_after_indent(body: str) -> str | None:
+    """Return content after 0-3 spaces; four-space indentation is code, not a block start."""
+    indent = len(body) - len(body.lstrip(" "))
+    if indent > 3:
+        return None
+    return body[indent:]
+
+
+def _raw_html_start(content: str) -> tuple[str, re.Pattern[str] | None] | None:
+    """Classify supported GFM raw-HTML block starts; unknown tag-like starts fail closed."""
+    lowered = content.lower()
+    if HTML_TYPE1_RE.match(content[1:]) if content.startswith("<") else False:
+        return "until_match", HTML_TYPE1_END_RE
+    if content.startswith("<?"):
+        return "until_match", re.compile(r"\?>")
+    if re.match(r"<![A-Z]", content):
+        return "until_match", re.compile(r">")
+    if lowered.startswith("<![cdata["):
+        return "until_match", re.compile(r"\]\]>")
+    if content.startswith("<") and HTML_TYPE6_RE.match(content[1:]):
+        return "until_blank", None
+    if content.startswith("<") and HTML_TAG_LIKE_RE.match(content[1:]):
+        raise ValueError(
+            "Raw HTML-like tag syntax is unsupported in references/eval-scenarios.md; "
+            "use Markdown/plain text so eval-control parsing remains deterministic"
+        )
+    return None
+
+
+def effective_markdown(text: str) -> str:
+    """Blank non-Markdown GFM blocks while preserving visible line structure.
+
+    This is intentionally bounded to the eval-control surface. It handles HTML comments,
+    fenced code, GFM raw-HTML block types 1/3/4/5/6, and fails closed on other tag-like
+    starts rather than pretending to implement a general-purpose Markdown renderer.
+    """
     output: list[str] = []
     fence_char: str | None = None
     fence_len = 0
+    html_mode: str | None = None
+    html_end_re: re.Pattern[str] | None = None
 
     for line in text.splitlines(keepends=True):
         body = line.rstrip("\r\n")
-        if fence_char is None:
-            match = FENCE_OPEN_RE.match(body)
-            if match:
-                fence = match.group("fence")
-                info = match.group("info")
-                # CommonMark backtick info strings cannot themselves contain backticks.
-                if fence.startswith("`") and "`" in info:
-                    output.append(line)
-                    continue
-                fence_char = fence[0]
-                fence_len = len(fence)
-                output.append(_line_ending(line))
-                continue
-            output.append(line)
+        ending = _line_ending(line)
+
+        if fence_char is not None:
+            closing = re.fullmatch(
+                rf" {{0,3}}{re.escape(fence_char)}{{{fence_len},}}[ \t]*",
+                body,
+            )
+            output.append(ending)
+            if closing:
+                fence_char = None
+                fence_len = 0
             continue
 
-        closing = re.fullmatch(
-            rf" {{0,3}}{re.escape(fence_char)}{{{fence_len},}}[ \t]*",
-            body,
-        )
-        output.append(_line_ending(line))
-        if closing:
-            fence_char = None
-            fence_len = 0
+        if html_mode == "comment":
+            output.append(ending)
+            if "-->" in body:
+                html_mode = None
+            continue
+
+        if html_mode == "until_match":
+            output.append(ending)
+            if html_end_re is not None and html_end_re.search(body):
+                html_mode = None
+                html_end_re = None
+            continue
+
+        if html_mode == "until_blank":
+            if not body.strip():
+                html_mode = None
+                output.append(line)
+            else:
+                output.append(ending)
+            continue
+
+        content = _content_after_indent(body)
+        if content is not None and content.startswith("<!--"):
+            output.append(ending)
+            if "-->" not in content[4:]:
+                html_mode = "comment"
+            continue
+
+        match = FENCE_OPEN_RE.match(body)
+        if match:
+            fence = match.group("fence")
+            info = match.group("info")
+            # GFM/CommonMark backtick info strings cannot themselves contain backticks.
+            if not (fence.startswith("`") and "`" in info):
+                fence_char = fence[0]
+                fence_len = len(fence)
+                output.append(ending)
+                continue
+
+        if content is not None:
+            raw_html = _raw_html_start(content)
+            if raw_html is not None:
+                html_mode, html_end_re = raw_html
+                output.append(ending)
+                if html_mode == "until_match" and html_end_re is not None and html_end_re.search(content):
+                    html_mode = None
+                    html_end_re = None
+                continue
+
+        output.append(line)
 
     return "".join(output)
 
 
-def effective_markdown(text: str) -> str:
-    """Return Markdown text that can contribute visible headings/tables to these controls."""
-    without_fences = strip_fenced_code_blocks(text)
-
-    def blank_comment(match: re.Match[str]) -> str:
-        return "\n" * match.group(0).count("\n")
-
-    return HTML_COMMENT_RE.sub(blank_comment, without_fences)
-
-
 def parse_eval_ids(text: str) -> list[str]:
-    """Return eval IDs from effective Markdown headings, excluding hidden/example content."""
+    """Return eval IDs from effective top-level ATX headings."""
     return EVAL_HEADING_RE.findall(effective_markdown(text))

--- a/tools/markdown_eval.py
+++ b/tools/markdown_eval.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-EVAL_HEADING_RE = re.compile(r"^ {0,3}###[ \t]+([A-Z]+)\.[ \t]+", re.MULTILINE)
+EVAL_HEADING_RE = re.compile(r"^ {0,3}###[ \t]+([A-Z]+)\.[ \t]+[^ \t\r\n]", re.MULTILINE)
 FENCE_OPEN_RE = re.compile(r"^ {0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
 HTML_TYPE1_RE = re.compile(r"^(?:script|pre|style)(?=[\t >]|$)", re.IGNORECASE)
 HTML_TYPE1_END_RE = re.compile(r"</(?:script|pre|style)>", re.IGNORECASE)

--- a/tools/markdown_eval.py
+++ b/tools/markdown_eval.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-EVAL_HEADING_RE = re.compile(r"^ {0,3}###\s+([A-Z]+)\.\s+", re.MULTILINE)
+EVAL_HEADING_RE = re.compile(r"^ {0,3}###[ \t]+([A-Z]+)\.[ \t]+", re.MULTILINE)
 FENCE_OPEN_RE = re.compile(r"^ {0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
 HTML_TYPE1_RE = re.compile(r"^(?:script|pre|style)(?=[\t >]|$)", re.IGNORECASE)
 HTML_TYPE1_END_RE = re.compile(r"</(?:script|pre|style)>", re.IGNORECASE)
@@ -42,14 +42,13 @@ def _content_after_indent(body: str) -> str | None:
 
 def _raw_html_start(content: str) -> tuple[str, re.Pattern[str] | None] | None:
     """Classify supported GFM raw-HTML block starts; unknown tag-like starts fail closed."""
-    lowered = content.lower()
     if HTML_TYPE1_RE.match(content[1:]) if content.startswith("<") else False:
         return "until_match", HTML_TYPE1_END_RE
     if content.startswith("<?"):
         return "until_match", re.compile(r"\?>")
     if re.match(r"<![A-Z]", content):
         return "until_match", re.compile(r">")
-    if lowered.startswith("<![cdata["):
+    if content.startswith("<![CDATA["):
         return "until_match", re.compile(r"\]\]>")
     if content.startswith("<") and HTML_TYPE6_RE.match(content[1:]):
         return "until_blank", None

--- a/tools/markdown_eval.py
+++ b/tools/markdown_eval.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Shared effective-Markdown parsing for deterministic evaluation controls."""
+from __future__ import annotations
+
+import re
+
+EVAL_HEADING_RE = re.compile(r"^###\s+([A-Z]+)\.\s+", re.MULTILINE)
+FENCE_OPEN_RE = re.compile(r"^ {0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+HTML_COMMENT_RE = re.compile(r"<!--.*?(?:-->|\Z)", re.DOTALL)
+
+
+def _line_ending(line: str) -> str:
+    if line.endswith("\r\n"):
+        return "\r\n"
+    if line.endswith("\n"):
+        return "\n"
+    return ""
+
+
+def strip_fenced_code_blocks(text: str) -> str:
+    """Blank fenced code while preserving line structure for later Markdown parsing."""
+    output: list[str] = []
+    fence_char: str | None = None
+    fence_len = 0
+
+    for line in text.splitlines(keepends=True):
+        body = line.rstrip("\r\n")
+        if fence_char is None:
+            match = FENCE_OPEN_RE.match(body)
+            if match:
+                fence = match.group("fence")
+                info = match.group("info")
+                # CommonMark backtick info strings cannot themselves contain backticks.
+                if fence.startswith("`") and "`" in info:
+                    output.append(line)
+                    continue
+                fence_char = fence[0]
+                fence_len = len(fence)
+                output.append(_line_ending(line))
+                continue
+            output.append(line)
+            continue
+
+        closing = re.fullmatch(
+            rf" {{0,3}}{re.escape(fence_char)}{{{fence_len},}}[ \t]*",
+            body,
+        )
+        output.append(_line_ending(line))
+        if closing:
+            fence_char = None
+            fence_len = 0
+
+    return "".join(output)
+
+
+def effective_markdown(text: str) -> str:
+    """Return Markdown text that can contribute visible headings/tables to these controls."""
+    without_fences = strip_fenced_code_blocks(text)
+
+    def blank_comment(match: re.Match[str]) -> str:
+        return "\n" * match.group(0).count("\n")
+
+    return HTML_COMMENT_RE.sub(blank_comment, without_fences)
+
+
+def parse_eval_ids(text: str) -> list[str]:
+    """Return eval IDs from effective Markdown headings, excluding hidden/example content."""
+    return EVAL_HEADING_RE.findall(effective_markdown(text))

--- a/tools/validate_skill.py
+++ b/tools/validate_skill.py
@@ -10,6 +10,12 @@ import sys
 from collections import Counter
 from pathlib import Path
 
+TOOLS_DIR = Path(__file__).resolve().parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+from markdown_eval import effective_markdown, parse_eval_ids
+
 REQUIRED_RUNTIME_PATHS = (
     "SKILL.md",
     "agents/openai.yaml",
@@ -33,7 +39,6 @@ REQUIRED_DIRECT_ROUTER_TARGETS = tuple(
 FRONTMATTER_RE = re.compile(r"\A---\n(?P<body>.*?)\n---\n", re.DOTALL)
 LINK_RE = re.compile(r"\[[^\]]+\]\((?!https?://|mailto:|#)([^)]+)\)")
 NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
-EVAL_HEADING_RE = re.compile(r"^###\s+([A-Z]+)\.\s+", re.MULTILINE)
 SUPPLEMENTAL_EVAL_HEADING = "### Supplemental retrieval index"
 LEGACY_UNINDEXED_EVAL_MAX_ID = "DJ"
 PROJECT_GOAL_ROW_RE = re.compile(r"^\|\s*`(G\d{2})`(?:\s+[^|]*)?\s*\|", re.MULTILINE)
@@ -178,10 +183,6 @@ def int_to_eval_id(value: int) -> str:
     return "".join(reversed(chars))
 
 
-def parse_eval_ids(text: str) -> list[str]:
-    return EVAL_HEADING_RE.findall(text)
-
-
 def validate_eval_ids(text: str) -> set[str]:
     eval_ids = parse_eval_ids(text)
     if not eval_ids:
@@ -209,31 +210,53 @@ def parse_eval_anchors(cell: str, context: str) -> set[str]:
     return set(values)
 
 
+def parse_table_cells(line: str) -> list[str] | None:
+    if not line.startswith("|") or not line.endswith("|"):
+        return None
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
 def parse_supplemental_eval_ids(text: str) -> set[str] | None:
+    visible = effective_markdown(text)
     marker = f"{SUPPLEMENTAL_EVAL_HEADING}\n"
-    count = text.count(marker)
+    count = visible.count(marker)
     if count == 0:
         return None
     if count != 1:
         fail("Supplemental retrieval index must appear exactly once")
 
-    section = text.split(marker, 1)[1]
+    section = visible.split(marker, 1)[1]
     next_h2 = re.search(r"(?m)^##\s+", section)
     if next_h2:
         section = section[: next_h2.start()]
 
+    lines = section.splitlines()
+    expected_header = ["Change surface", "Supplemental eval IDs"]
+    header_indexes = [
+        index for index, line in enumerate(lines) if parse_table_cells(line) == expected_header
+    ]
+    if len(header_indexes) != 1:
+        fail("Supplemental retrieval index must contain exactly one navigation table")
+
+    header_index = header_indexes[0]
+    if header_index + 1 >= len(lines):
+        fail("Supplemental retrieval index table is missing its separator row")
+    separator = parse_table_cells(lines[header_index + 1])
+    if separator is None or len(separator) != 2 or not all(
+        re.fullmatch(r":?-{3,}:?", cell) for cell in separator
+    ):
+        fail("Supplemental retrieval index table has an invalid separator row")
+
     observed: list[str] = []
-    for line in section.splitlines():
-        if not line.startswith("|"):
-            continue
-        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+    for line in lines[header_index + 2 :]:
+        if not line.strip():
+            break
+        cells = parse_table_cells(line)
+        if cells is None:
+            break
         if len(cells) != 2:
             fail(f"Supplemental retrieval index row must have exactly two columns: {line}")
         surface, eval_cell = cells
-        if surface == "Change surface":
-            continue
-        if all(set(cell) <= {"-", ":", " "} for cell in cells):
-            continue
         if not surface:
             fail("Supplemental retrieval index surface must not be empty")
         ids = [part.strip().strip("`") for part in eval_cell.split(",") if part.strip()]

--- a/tools/validate_skill.py
+++ b/tools/validate_skill.py
@@ -34,6 +34,8 @@ FRONTMATTER_RE = re.compile(r"\A---\n(?P<body>.*?)\n---\n", re.DOTALL)
 LINK_RE = re.compile(r"\[[^\]]+\]\((?!https?://|mailto:|#)([^)]+)\)")
 NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 EVAL_HEADING_RE = re.compile(r"^###\s+([A-Z]+)\.\s+", re.MULTILINE)
+SUPPLEMENTAL_EVAL_HEADING = "### Supplemental retrieval index"
+LEGACY_UNINDEXED_EVAL_MAX_ID = "DJ"
 PROJECT_GOAL_ROW_RE = re.compile(r"^\|\s*`(G\d{2})`(?:\s+[^|]*)?\s*\|", re.MULTILINE)
 GOAL_ROW_RE = re.compile(
     r"^\|\s*`(?P<goal>G\d{2})`(?:\s+[^|]*)?\s*\|\s*(?P<rules>.*?)\s*\|\s*(?P<evals>.*?)\s*\|\s*(?P<coverage>.*?)\s*\|\s*$",
@@ -207,7 +209,50 @@ def parse_eval_anchors(cell: str, context: str) -> set[str]:
     return set(values)
 
 
-def validate_traceability(repo_root: Path, skill_dir: Path) -> None:
+def parse_supplemental_eval_ids(text: str) -> set[str] | None:
+    marker = f"{SUPPLEMENTAL_EVAL_HEADING}\n"
+    count = text.count(marker)
+    if count == 0:
+        return None
+    if count != 1:
+        fail("Supplemental retrieval index must appear exactly once")
+
+    section = text.split(marker, 1)[1]
+    next_h2 = re.search(r"(?m)^##\s+", section)
+    if next_h2:
+        section = section[: next_h2.start()]
+
+    observed: list[str] = []
+    for line in section.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) != 2:
+            fail(f"Supplemental retrieval index row must have exactly two columns: {line}")
+        surface, eval_cell = cells
+        if surface == "Change surface":
+            continue
+        if all(set(cell) <= {"-", ":", " "} for cell in cells):
+            continue
+        if not surface:
+            fail("Supplemental retrieval index surface must not be empty")
+        ids = [part.strip().strip("`") for part in eval_cell.split(",") if part.strip()]
+        if not ids:
+            fail(f"Supplemental retrieval index row {surface!r} must include evaluation IDs")
+        invalid = [value for value in ids if not re.fullmatch(r"[A-Z]+", value)]
+        if invalid:
+            fail(f"Supplemental retrieval index contains invalid evaluation ID syntax: {invalid}")
+        observed.extend(ids)
+
+    duplicates = sorted(value for value, count in Counter(observed).items() if count > 1)
+    if duplicates:
+        fail(f"Supplemental retrieval index contains duplicate evaluation IDs: {duplicates}")
+    return set(observed)
+
+
+def validate_traceability(
+    repo_root: Path, skill_dir: Path, *, allow_legacy_unindexed_evals: bool = False
+) -> None:
     rule_map_path = repo_root / "design" / "RULE-MAP.md"
     goal_map_path = repo_root / "design" / "GOAL-MAP.md"
     project_spec_path = repo_root / "docs" / "PROJECT-SPEC.md"
@@ -217,7 +262,8 @@ def validate_traceability(repo_root: Path, skill_dir: Path) -> None:
     if missing_files:
         fail(f"Traceability source files are missing: {missing_files}")
 
-    eval_ids = validate_eval_ids(eval_path.read_text(encoding="utf-8"))
+    eval_text = eval_path.read_text(encoding="utf-8")
+    eval_ids = validate_eval_ids(eval_text)
 
     rule_text = rule_map_path.read_text(encoding="utf-8")
     rule_matches = list(RULE_ROW_RE.finditer(rule_text))
@@ -229,12 +275,14 @@ def validate_traceability(repo_root: Path, skill_dir: Path) -> None:
         fail(f"Duplicate canonical Rule rows/owners in design/RULE-MAP.md: {duplicate_rules}")
 
     rule_id_set = set(rule_ids)
+    rule_eval_ids: set[str] = set()
     for match in rule_matches:
         rule_id = match.group("rule")
         owner = match.group("owner").strip().strip("`").strip()
         if not owner:
             fail(f"Rule {rule_id} is missing a canonical owner")
         anchors = parse_eval_anchors(match.group("evals"), f"Rule {rule_id}")
+        rule_eval_ids.update(anchors)
         missing_anchors = sorted(anchors - eval_ids, key=eval_id_to_int)
         if missing_anchors:
             fail(f"Rule {rule_id} references missing evaluation IDs: {missing_anchors}")
@@ -266,6 +314,7 @@ def validate_traceability(repo_root: Path, skill_dir: Path) -> None:
         )
 
     mapped_rules: set[str] = set()
+    goal_eval_ids: set[str] = set()
     for match in goal_matches:
         goal_id = match.group("goal")
         referenced_rules = set(INLINE_RULE_RE.findall(match.group("rules")))
@@ -275,6 +324,7 @@ def validate_traceability(repo_root: Path, skill_dir: Path) -> None:
         mapped_rules.update(referenced_rules)
 
         anchors = parse_eval_anchors(match.group("evals"), f"Goal {goal_id}")
+        goal_eval_ids.update(anchors)
         missing_anchors = sorted(anchors - eval_ids, key=eval_id_to_int)
         if missing_anchors:
             fail(f"Goal {goal_id} references missing evaluation IDs: {missing_anchors}")
@@ -282,6 +332,44 @@ def validate_traceability(repo_root: Path, skill_dir: Path) -> None:
     orphan_rules = sorted(rule_id_set - mapped_rules)
     if orphan_rules:
         fail(f"Canonical Rule IDs are not mapped to any Goal in design/GOAL-MAP.md: {orphan_rules}")
+
+
+    anchored_eval_ids = rule_eval_ids | goal_eval_ids
+    unanchored_eval_ids = eval_ids - anchored_eval_ids
+    supplemental_eval_ids = parse_supplemental_eval_ids(eval_text)
+    if supplemental_eval_ids is None:
+        if unanchored_eval_ids:
+            if allow_legacy_unindexed_evals:
+                if max(eval_id_to_int(value) for value in eval_ids) > eval_id_to_int(
+                    LEGACY_UNINDEXED_EVAL_MAX_ID
+                ):
+                    fail(
+                        "Legacy unindexed-eval compatibility is allowed only for pre-v1.3.2 eval inventories ending at or before DJ"
+                    )
+            else:
+                fail(
+                    "Unanchored evaluation scenarios require a supplemental retrieval index: "
+                    f"{sorted(unanchored_eval_ids, key=eval_id_to_int)}"
+                )
+    else:
+        unknown_supplemental = supplemental_eval_ids - eval_ids
+        if unknown_supplemental:
+            fail(
+                "Supplemental retrieval index references missing evaluation IDs: "
+                f"{sorted(unknown_supplemental, key=eval_id_to_int)}"
+            )
+        duplicate_anchor_coverage = supplemental_eval_ids & anchored_eval_ids
+        if duplicate_anchor_coverage:
+            fail(
+                "Supplemental retrieval index must contain only Rule/Goal-unanchored evaluation IDs: "
+                f"{sorted(duplicate_anchor_coverage, key=eval_id_to_int)}"
+            )
+        missing_supplemental = unanchored_eval_ids - supplemental_eval_ids
+        if missing_supplemental:
+            fail(
+                "Unanchored evaluation scenarios are missing from the supplemental retrieval index: "
+                f"{sorted(missing_supplemental, key=eval_id_to_int)}"
+            )
 
 
 def validate_state_tokens(skill_dir: Path) -> None:
@@ -333,6 +421,14 @@ def main() -> int:
         type=Path,
         help="Compare the supplied Skill source exactly against this SHA-256 baseline manifest.",
     )
+    parser.add_argument(
+        "--allow-legacy-unindexed-evals",
+        action="store_true",
+        help=(
+            "Compatibility only for frozen pre-v1.3.2 prototype fixtures whose eval inventory predates DK; "
+            "never valid for current v1.3.2+ Skill validation."
+        ),
+    )
     args = parser.parse_args()
 
     skill_dir = args.skill_dir.resolve()
@@ -342,7 +438,11 @@ def main() -> int:
     if args.baseline_manifest is None:
         validate_direct_router(skill_dir)
         validate_state_tokens(skill_dir)
-        validate_traceability(skill_dir.parent, skill_dir)
+        validate_traceability(
+            skill_dir.parent,
+            skill_dir,
+            allow_legacy_unindexed_evals=args.allow_legacy_unindexed_evals,
+        )
     validate_python(skill_dir)
     if args.baseline_manifest is not None:
         validate_baseline(skill_dir, args.baseline_manifest.resolve())


### PR DESCRIPTION
Closes #94

Parent research: #86
Selected research lane: #92 (`SELECT_B2`), reconciled with #93.

## Exact review envelope

- Integration target: `main@45bdabd2fd131daec3c630b45c16bdced670cc57`
- Current candidate: `79eaecfc533de25b11f6dfe12dec00b75285f4ed`
- Previous reviewed candidates: `592c59ba31e3e307364514e9fd208438db500ef2`, `555c4c2876831ad9248b03a6caf79e7dc3e4daff`, `b47e7909c19f7d78948fa33fc4624e1b52d64bbd`, `324d9e90182499899e8097b491e1c4ba2fbe43f3`
- Released control: `v1.3.2`
- RiskLevel: `MEDIUM`
- CoordinationBaseline: `STANDARD`
- AssuranceLevel: `HIGH_ASSURANCE`
- DeliveryRequirement: `INTEGRATION_ONLY`

Four fresh independent HIGH_ASSURANCE reviews of superseded candidates returned `CHANGES_REQUIRED`. Every REQUIRED finding was independently reproduced before remediation. The latest superseded candidate `324d9e9...` allowed a titleless `### DK.` line with only trailing spaces/tabs to satisfy eval inventory; current candidate `79eaecf...` closes that exact path.

## What changed

- adds a same-file, navigation-only supplemental eval retrieval index for the 24 scenarios outside the existing Rule+Goal eval-anchor union;
- makes that supplemental set mechanically equal the current anchor complement;
- preserves frozen pre-v1.3.2 experiment compatibility with a bounded legacy flag rejected for current inventories;
- preserves the immutable v1.2.2 full representation baseline and adds an immutable v1.3.2 eval-inventory control;
- uses one shared bounded GFM block parser for validator and current-control checker;
- ignores eval-looking content inside HTML comments, fenced code, and the bounded supported raw-HTML block forms;
- recognizes valid ATX eval headings with 0–3 leading spaces and same-line horizontal whitespace only;
- prevents physical-line crossing before/after the eval ID and requires at least one non-horizontal-whitespace title character on that same line;
- recognizes Type-5 CDATA only for exact case-sensitive `<![CDATA[`;
- prevents comment/fence/raw-HTML state from fabricating or hiding eval inventory in the tested families;
- treats unsupported tag-like raw-HTML starts in the eval-control surface as fail-closed;
- restricts supplemental parsing to the actual visible navigation table;
- adds direct and real-CLI/end-to-end regression coverage for comments, fences, raw HTML, ATX indentation, cross-line pseudo-headings, titleless space/tab pseudo-headings, and uppercase/lowercase/mixed-case CDATA behavior.

## Explicitly unchanged

- no `SKILL.md` routing change;
- no Worker/helper/Governance/review/release runtime-policy rewrite;
- no lifecycle state, predicate, gate, or canonical Rule-owner change;
- no eval regrouping, renumbering, file split, or Regression Guard rewrite;
- all 115 existing scenario bodies `A..DK` remain byte-identical to v1.3.2;
- the entire Regression Guard remains byte-identical to v1.3.2 (`sha256=7a7c338003690f186d0c0bb2f2a43ed8ac6ead992478638684f3d1e9c3926d5d`);
- no VERSION bump or release work.

## Latest deterministic evidence

At exact committed candidate `79eaecfc533de25b11f6dfe12dec00b75285f4ed`:

- latest F-003 was independently reproduced against exact prior candidate `324d9e9...` through both actual validator and checker;
- direct parser rejects `### DK.   \n...` and `### DK.\t\t\n...` while normal same-line titles, tab separators, and 0–3-space indentation remain recognized;
- real end-to-end space/tab tests remove REAL `DK`, retain the real visible supplemental DK row, inject only the titleless pseudo-heading, require validator failure, require checker exit `1`, require exact error `current v1.3.2 evaluation scenarios removed: ['DK']`, and assert `DK` is absent from candidate inventory;
- previous cross-line, CDATA, comment/fence, `<pre>`, and `<div>` regression tests remain green;
- full local workflow-equivalent validation passed, including Phase 2, preflight, Phase 6, historical v1.2.2 + current v1.3.2 controls, Phase 7, all frozen representation experiments, Phase C, model-trial tests, release-intent, packaging/platform packaging, publisher tests, immutable v1.0.0 baseline, clean runtime source, and `git diff --check`;
- all existing 115 scenario bodies and the Regression Guard remain byte-identical to v1.3.2.

Exact-head GitHub Actions:

- workflow: `Validate and Release Skill`
- run: `33710408273`
- exact HEAD: `79eaecfc533de25b11f6dfe12dec00b75285f4ed`
- conclusion: `SUCCESS`
- validate job: `SUCCESS`
- all configured validation/control/benchmark/model-trial/package/baseline/runtime-source steps: `SUCCESS`
- release job: `SKIPPED`

No actual-model latency/accuracy/comprehension improvement is claimed. This PR remains a deterministic eval-retrieval/regression-protection change only.

## Gate

Do not integrate until a fresh independent `HIGH_ASSURANCE` review approves the exact current target/candidate envelope.